### PR TITLE
Fixing bug with legacy and current session ID properties in analysis

### DIFF
--- a/lib/geardb.py
+++ b/lib/geardb.py
@@ -791,16 +791,21 @@ class Analysis:
         except:
             dataset_id = jsn["dataset_id"]
 
+        try:
+            session_id = jsn["user_session_id"]
+        except:
+            session_id = jsn["analysis_session_id"]
+
         ana = Analysis(
-            id=jsn['id'], dataset_id=dataset_id, label=jsn['label'], session_id=jsn['user_session_id'],
+            id=jsn['id'], dataset_id=dataset_id, label=jsn['label'], session_id=session_id,
             user_id=None, type=jsn['type']
         )
 
-        ## get the rest
+        ## get the rest of the properties
         for k in jsn:
             if not hasattr(ana, k):
                 # some were manually named, skip them
-                if k not in ['user_session_id']:
+                if k not in ['user_session_id', 'analysis_session_id']:
                     setattr(ana, k, jsn[k])
 
         return ana
@@ -1920,7 +1925,7 @@ class Dataset:
         conn.close()
 
         return self.displays
-    
+
     def get_owner_display(self, is_multigene=False):
         """
         Returns the display object for the owner of the dataset.
@@ -2507,7 +2512,7 @@ class Gene:
 
         elif this.domain_label == 'nemo':
             pass
-            
+
         for dbxref in self.dbxrefs:
             source = dbxref['source']
 


### PR DESCRIPTION
This pull request includes a change in the `lib/geardb.py` file to improve the handling of session IDs when converting from JSON. The most important changes are:

* Added a try-except block to handle both `user_session_id` and `analysis_session_id` when parsing the JSON input in the `from_json` method. This ensures that the correct session ID is assigned regardless of which key is present in the JSON.
* Updated the `Analysis` object instantiation to use the `session_id` variable, which now correctly handles both possible session ID keys.
* Modified the loop that sets additional properties to skip both `user_session_id` and `analysis_session_id`, preventing them from being overwritten.