### PR TITLE
fixed bug with not restoring original adata when min_genes slider is lowered

### DIFF
--- a/services/spatial/panel_app.py
+++ b/services/spatial/panel_app.py
@@ -580,9 +580,11 @@ class SpatialPanel(pn.viewable.Viewer):
         # SAdkins - Have not quite figured out when to use "watch" but I think it mostly applies when a callback does not return a value
         def refresh_dataframe_callback(value):
             self.dataset_adata = self.dataset_adata_orig.copy()
+            self.adata = self.adata_orig.copy()
 
             with self.normal_pane.param.update(loading=True) \
                 , self.zoom_pane.param.update(loading=True) \
+                , self.umap_pane.param.update(loading=True) \
                 , self.violin_pane.param.update(loading=True) \
                 , self.min_genes_slider.param.update(disabled=True):
                 self.refresh_dataframe(value)
@@ -633,12 +635,14 @@ class SpatialPanel(pn.viewable.Viewer):
 
 
         self.dataset_adata_orig = adata_pkg["adata"] # Original dataset adata
-        self.dataset_adata = self.dataset_adata_orig.copy() # Copy we manipulate
-        self.adata = self.dataset_adata.copy()  # Adata to get dataframe from
+        self.dataset_adata = self.dataset_adata_orig.copy() # Copy we manipulate (filtering, etc.)
+        self.adata = self.dataset_adata.copy()  # adata object to use for plotting
 
         # Modify the adata object to use the projection ID if it exists
         if self.projection_id:
             self.adata = self.create_projection_adata()
+
+        self.adata_orig = self.adata.copy() # This is to restore when the min_genes slider is changed
 
         self.spatial_img = None
         if adata_pkg["img_name"]:
@@ -648,7 +652,8 @@ class SpatialPanel(pn.viewable.Viewer):
 
         yield self.refresh_dataframe(self.min_genes)
 
-        with self.umap_pane.param.update(loading=True):
+        with self.umap_pane.param.update(loading=True) \
+            , self.min_genes_slider.param.update(disabled=True):
             self.add_umap()
 
     def prep_sdata(self):


### PR DESCRIPTION
This pull request includes updates to the `services/spatial/panel_app.py` file to enhance data handling and improve the user interface during data updates. The most important changes include adding a new copy of the `adata` object, updating the loading state of additional UI components, and ensuring the `adata` object can be restored when the `min_genes` slider is changed.

Enhancements to data handling and UI updates:

* [`services/spatial/panel_app.py`](diffhunk://#diff-c26c3b35cd2fdd78f7ddbc517c32986d7c7d1377f24018ddc45d94fa87e0076bL636-R646): Added a new copy of the `adata` object (`self.adata_orig`) to allow restoration when the `min_genes` slider is changed.
* [`services/spatial/panel_app.py`](diffhunk://#diff-c26c3b35cd2fdd78f7ddbc517c32986d7c7d1377f24018ddc45d94fa87e0076bR583-R587): Updated the loading state of the `umap_pane` and `min_genes_slider` UI components during data refresh and UMAP addition. [[1]](diffhunk://#diff-c26c3b35cd2fdd78f7ddbc517c32986d7c7d1377f24018ddc45d94fa87e0076bR583-R587) [[2]](diffhunk://#diff-c26c3b35cd2fdd78f7ddbc517c32986d7c7d1377f24018ddc45d94fa87e0076bL651-R656)…changed