### PR TITLE
Restore viability of some legacy multigene plot configurations

### DIFF
--- a/lib/gear/mg_plotting.py
+++ b/lib/gear/mg_plotting.py
@@ -253,7 +253,7 @@ def create_clusterbar_z_value(flip_axes, groups_and_colors, key, val):
     return [[ groups_and_colors[key]["groups"].index(cgm["group"]) for cgm in val ]]
 
 #@profile(stream=fp)
-def create_clustergram(df, groupby_filters, gene_symbols, is_log10=False, cluster_obs=False, cluster_genes=False, flip_axes=False, center_around_zero=False
+def create_clustergram(df, gene_symbols, is_log10=False, cluster_obs=False, cluster_genes=False, flip_axes=False, center_around_zero=False
                        , distance_metric="euclidean", colorscale=None, reverse_colorscale=False, hide_obs_labels=False, hide_gene_labels=False):
     """Generate a clustergram (heatmap+dendrogram).  Returns Plotly figure and dendrogram trace info."""
 
@@ -266,11 +266,6 @@ def create_clustergram(df, groupby_filters, gene_symbols, is_log10=False, cluste
 
     # NOTE: I attempted to use multicateogry axis labels for x-axis but the z-values were not lining up correctly
     # This was true even with a plain go.Heatmap
-
-    # Drop the obs metadata now that the dataframe is sorted
-    # They cannot be in there when the clustergram is made
-    # But save it to add back in later
-    df_cols = pd.concat([df.pop(cat) for cat in groupby_filters], axis=1)
 
     df = df if flip_axes else df.transpose()
     columns = list(df.columns.values)

--- a/www/api/resources/mg_plotly_data.py
+++ b/www/api/resources/mg_plotly_data.py
@@ -538,7 +538,7 @@ class MultigeneDashData(Resource):
                 if not primary_col:
                     return {
                         'success': -1,
-                        'message': "The 'primary_col' option is required for matrixplots. Please update this curation"
+                        'message': "A primary grouping is required for matrixplots. Please update this curation"
                     }
 
                 grouped = df.groupby(groupby_filters, observed=False)

--- a/www/api/resources/mg_plotly_data.py
+++ b/www/api/resources/mg_plotly_data.py
@@ -507,28 +507,32 @@ class MultigeneDashData(Resource):
             if secondary_col and not primary_col == secondary_col:
                 groupby_filters.append(secondary_col)
 
+            # Clusterbar field handling
+            if matrixplot:
+                # In matrixplots, only primary/secondary groups can have clusterbars
+                # These will be added to the dataframe later
+                for field in clusterbar_fields:
+                    if field not in groupby_filters:
+
+                        return {
+                            'success': -1,
+                            'message': f"Clusterbar field '{field}' must be included in the primary or secondary groupings."
+                        }
+            else:
+                # Add clusterbar fields to the dataframe
+                for cf in clusterbar_fields:
+                        df[cf] = selected.obs[cf]
+
             for gb in groupby_filters:
-                df[gb] = selected.obs[gb]
+                if gb not in df:
+                    df[gb] = selected.obs[gb]
 
             if groupby_filters:
                 # For the remaining data, create a special composite index for the specified groupings
                 df['groupby_composite'] = create_composite_index_column(df, groupby_filters)
                 df['groupby_composite'] = df['groupby_composite'].astype('category')
 
-                # TODO: Allow all clusterbars if matrixplot = False
-                fields_to_remove = []
-                for field in clusterbar_fields:
-                    if field not in groupby_filters:
-                        # Remove field from clusterbar_fields if it is not in the groupby_filters
-                        print(f"Clusterbar field '{field}' must be included in the primary or secondary groupings. Removing field to ensure legacy plots work.", file=sys.stderr)
-                        fields_to_remove.append(field)
 
-                        #return {
-                        #    'success': -1,
-                        #    'message': f"Clusterbar field '{field}' must be included in the primary or secondary groupings."
-                        #}
-                for field in fields_to_remove:
-                    clusterbar_fields.remove(field)
 
             groupby_filters.append("groupby_composite")
 
@@ -560,9 +564,16 @@ class MultigeneDashData(Resource):
             if colorblind_mode:
                 colorscale = "cividis_r"
 
+            # Drop the obs metadata now that the dataframe is sorted
+            # They cannot be in there when the clustergram is made
+            # But save it to add back in later
+            cols_to_drop = mg.union(groupby_filters, clusterbar_fields)
+
+            orig_df = df.copy()
+            df_cols = pd.concat([df.pop(cat) for cat in cols_to_drop], axis=1)
+
             # "df" must be obs label for rows and genes for cols only
-            fig = mg.create_clustergram(df.copy()
-                , groupby_filters
+            fig = mg.create_clustergram(df
                 , normalized_genes_list
                 , is_log10
                 , cluster_obs
@@ -576,6 +587,7 @@ class MultigeneDashData(Resource):
                 , hide_gene_labels
                 )
 
+            df = orig_df
             clusterbar_indexes = mg.build_obs_group_indexes(df, filters, clusterbar_fields)
 
             # Create labels based only on the included filters

--- a/www/include/plot_config/pre_plot/advanced_heatmap.html
+++ b/www/include/plot_config/pre_plot/advanced_heatmap.html
@@ -11,7 +11,7 @@
     <div class="control">
         <label class="checkbox">
             <input class="js-dash-matrixplot" id="matrixplot" type="checkbox" checked>
-            Aggregate mean expression based on above groupings. Highly recommended for large datasets.
+            Aggregate mean expression based on selected primary and secondary groups. Highly recommended to keep checked unless the number of samples is small.
         </label>
     </div>
-</div>
+</div>44

--- a/www/js/multigene_curator.js
+++ b/www/js/multigene_curator.js
@@ -337,6 +337,39 @@ class GenesAsAxisHandler extends PlotHandler {
                 item.addEventListener("click", showPostHeatmapParamSubsection);
             }
 
+            // If matrixplot is unchecked enable all clusterbars.
+            for (const classElt of document.getElementsByClassName("js-dash-matrixplot")) {
+                classElt.addEventListener("change", (event) => {
+                    const checked = event.target.checked;
+                    if (checked) {
+                        // Get primary and secondary series
+                        const primarySeries = document.querySelector(".js-dash-primary").value;
+                        const secondarySeries = document.querySelector(".js-dash-secondary").value;
+                        const values = [];
+                        if (primarySeries) {
+                            values.push(primarySeries);
+                        }
+                        if (secondarySeries) {
+                            values.push(secondarySeries);
+                        }
+                        // If either series are selected, enable those checkboxes
+                        for (const innerClassElt of document.getElementsByClassName("js-dash-clusterbar-checkbox")) {
+                            if (values.includes(innerClassElt.value)) {
+                                innerClassElt.disabled = false;
+                            } else {
+                                innerClassElt.checked = false;
+                                innerClassElt.disabled = true;
+                            }
+                        }
+                    } else {
+                        for (const innerClassElt of document.getElementsByClassName("js-dash-clusterbar-checkbox")) {
+                            innerClassElt.disabled = false;
+                        }
+                    }
+                })
+            }
+
+
             // Ensure only clusterbar checkboxes that match the primary and secondary series are enabled to be checked
             // If a checkbox is checked and the primary or secondary series is changed, uncheck the checkbox
             for (const classElt of document.getElementsByClassName("js-dash-primary")) {
@@ -351,12 +384,17 @@ class GenesAsAxisHandler extends PlotHandler {
                         values.push(secondarySeries);
                     }
 
-                    for (const innerClassElt of document.getElementsByClassName("js-dash-clusterbar-checkbox")) {
-                        if (!(values.includes(innerClassElt.value))) {
-                            innerClassElt.checked = false;
-                            innerClassElt.disabled = true;
-                        } else {
-                            innerClassElt.disabled = false;
+                    // Get matrixplot value
+                    const matrixplot = document.querySelector(".js-dash-matrixplot").checked;
+
+                    if (matrixplot) {
+                        for (const innerClassElt of document.getElementsByClassName("js-dash-clusterbar-checkbox")) {
+                            if (values.includes(innerClassElt.value)) {
+                                innerClassElt.disabled = false;
+                            } else {
+                                innerClassElt.checked = false;
+                                innerClassElt.disabled = true;
+                            }
                         }
                     }
                 })
@@ -373,12 +411,17 @@ class GenesAsAxisHandler extends PlotHandler {
                         values.push(secondarySeries);
                     }
 
-                    for (const innerClassElt of document.getElementsByClassName("js-dash-clusterbar-checkbox")) {
-                        if (!(values.includes(innerClassElt.value))) {
-                            innerClassElt.checked = false;
-                            innerClassElt.disabled = true;
-                        } else {
-                            innerClassElt.disabled = false;
+                    // Get matrixplot value
+                    const matrixplot = document.querySelector(".js-dash-matrixplot").checked;
+
+                    if (matrixplot) {
+                        for (const innerClassElt of document.getElementsByClassName("js-dash-clusterbar-checkbox")) {
+                            if (values.includes(innerClassElt.value)) {
+                                innerClassElt.disabled = false;
+                            } else {
+                                innerClassElt.checked = false;
+                                innerClassElt.disabled = true;
+                            }
                         }
                     }
                 })


### PR DESCRIPTION
This pull request includes several changes to improve the handling of clusterbar fields and streamline the creation of clustergrams. The most important changes include modifications to the `create_clustergram` function, updates to the `post` method in `mg_plotly_data.py`, and adjustments to the user interface for matrixplot options.

Changes to clusterbar field handling and clustergram creation:

* [`lib/gear/mg_plotting.py`](diffhunk://#diff-ab42103eeb96c77e06b1c8c0be1e3c84f00143239c9cf326af6b64570e7d9123L256-R256): Removed the `groupby_filters` parameter from the `create_clustergram` function, simplifying its signature.
* [`www/api/resources/mg_plotly_data.py`](diffhunk://#diff-4f71a1e0dee3ce3d9cb48a1f1e795d92468746f7202b472d56a27f057c9a4102R510-L531): Added logic to ensure clusterbar fields are included in primary or secondary groupings for matrixplots, and moved the dropping of observation metadata to the appropriate section. [[1]](diffhunk://#diff-4f71a1e0dee3ce3d9cb48a1f1e795d92468746f7202b472d56a27f057c9a4102R510-L531) [[2]](diffhunk://#diff-4f71a1e0dee3ce3d9cb48a1f1e795d92468746f7202b472d56a27f057c9a4102R567-R576)

User interface adjustments for matrixplot options:

* [`www/include/plot_config/pre_plot/advanced_heatmap.html`](diffhunk://#diff-4336a8768ddf39df0a11d9654bcd6327139fcdfb054ae1c69f96547bddccccc1L14-R17): Updated the label for the matrixplot checkbox to clarify its recommendation for large datasets.
* [`www/js/multigene_curator.js`](diffhunk://#diff-3a4bb6af99e5e24f7bb631e8db75595a45ece529dd2e1d65941f85fff3daa58aR340-R372): Added event listeners to enable or disable clusterbar checkboxes based on the matrixplot checkbox state and primary/secondary series selections. [[1]](diffhunk://#diff-3a4bb6af99e5e24f7bb631e8db75595a45ece529dd2e1d65941f85fff3daa58aR340-R372) [[2]](diffhunk://#diff-3a4bb6af99e5e24f7bb631e8db75595a45ece529dd2e1d65941f85fff3daa58aR387-R397) [[3]](diffhunk://#diff-3a4bb6af99e5e24f7bb631e8db75595a45ece529dd2e1d65941f85fff3daa58aR414-R424)