### PR TITLE
#1094 - Changed dataset_id url params to share_id

### DIFF
--- a/www/cgi/get_shared_info.cgi
+++ b/www/cgi/get_shared_info.cgi
@@ -6,7 +6,7 @@ display with selected gene information. If so, returns the gene information.
 
 Also returns some basic dataset information for display for a dataset share.
 
-If only a layout share is given, the first dataset in the layout is retrieved 
+If only a layout share is given, the first dataset in the layout is retrieved
 and information is returned for that dataset.
 
 Returns a JSON object with the following
@@ -19,14 +19,16 @@ Returns a JSON object with the following
 }
 """
 
-import cgi, json
-import os, sys
+import cgi
 import configparser
 import json
+import os
+import sys
 
 lib_path = os.path.abspath(os.path.join('..', '..', 'lib'))
 sys.path.append(lib_path)
 import geardb
+
 
 def main():
     print('Content-Type: application/json\n\n')
@@ -40,9 +42,9 @@ def main():
     dataset = None
     owner = None
 
-    result = { 'gene_symbol': None, 'dataset_label': None, 
+    result = { 'gene_symbol': None, 'dataset_label': None,
               'layout_label': None, 'owner_name': None }
-    
+
     if dataset_share_id and dataset_share_id != 'null':
         dataset = geardb.get_dataset_by_share_id(share_id=dataset_share_id)
 
@@ -76,7 +78,7 @@ def main():
 
             except json.JSONDecodeError:
                 display_json = {}
-               
+
     print(json.dumps(result))
 
 if __name__ == '__main__':

--- a/www/js/classes/analysis.js
+++ b/www/js/classes/analysis.js
@@ -182,7 +182,8 @@ class Analysis {
         // create URL parameters
         const params = {
             session_id: this.analysisSessionId,
-            dataset_id: this.dataset.id,
+            //dataset_id: this.dataset.id,
+            share_id: this.dataset.share_id,
             analysis_id: this.id,
             type: "h5ad",
         }
@@ -195,7 +196,7 @@ class Analysis {
             const downloadUrl = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = downloadUrl;
-            a.download = `${this.dataset.id}.${this.id}.h5ad`;
+            a.download = `${this.dataset.share_id}.${this.id}.h5ad`;
             a.click();
         } catch (error) {
             console.error("Error downloading analysis h5ad", this);

--- a/www/js/classes/tilegrid.js
+++ b/www/js/classes/tilegrid.js
@@ -794,7 +794,7 @@ class DatasetTile {
         const dropdownContent = dropdownMenu.querySelector(".dropdown-content");
         const dropdownItems = dropdownContent.querySelectorAll('.dropdown-item');
 
-        const datasetId = dataset.id;
+        const shareId = dataset.share_id;
         const pubmedId = dataset.pubmed_id;
         const geoId = dataset.geo_id;
         const hasTarball = dataset.has_tarball;
@@ -853,7 +853,7 @@ class DatasetTile {
                 case "single-cell":
                     // Redirect to single-cell analysis workbench
                     if (hasH5ad) {
-                        const url = `./sc_workbench.html?dataset_id=${datasetId}`;
+                        const url = `./sc_workbench.html?share_id=${shareId}`;
                         //const url = `./sc_workbench.html?dataset_id=${datasetId}`;
                         item.href = url;
                     } else {
@@ -863,7 +863,7 @@ class DatasetTile {
                 case "compare":
                     // Redirect to comparison tool
                     if (hasH5ad) {
-                        const url = `./compare_datasets.html?dataset_id=${datasetId}`;
+                        const url = `./compare_datasets.html?share_id=${shareId}`;
                         item.href = url;
                     } else {
                         item.classList.add("is-hidden");
@@ -873,7 +873,7 @@ class DatasetTile {
                     // Redirect to single-gene curation tool
                     // TODO: It would be cool to pass in the gene symbol to the curation tool to auto-populate the gene symbol field
                     if (hasH5ad) {
-                        const url = `./dataset_curator.html?dataset_id=${datasetId}`;
+                        const url = `./dataset_curator.html?share_id=${shareId}`;
                         item.href = url;
                     } else {
                         item.classList.add("is-hidden");
@@ -883,7 +883,7 @@ class DatasetTile {
                     // Redirect to multi-gene curation tool
                     // TODO: It would be cool to pass in the gene symbols to the curation tool to auto-populate the gene symbol field
                     if (hasH5ad) {
-                        const url = `./multigene_curator.html?dataset_id=${datasetId}`;
+                        const url = `./multigene_curator.html?share_id=${shareId}`;
                         item.href = url;
                     } else {
                         item.classList.add("is-hidden");
@@ -893,7 +893,7 @@ class DatasetTile {
                     // Download dataset bundle
                     if (hasTarball && isDownloadable) {
                         try {
-                            const url = `./cgi/download_source_file.cgi?type=tarball&dataset_id=${datasetId}`;
+                            const url = `./cgi/download_source_file.cgi?type=tarball&share_id=${shareId}`;
                             item.href = url;
                         } catch (error) {
                             logErrorInConsole(error);
@@ -908,7 +908,7 @@ class DatasetTile {
                     // Download h5ad file
                     if (hasH5ad && isDownloadable) {
                         try {
-                            const url = `./cgi/download_source_file.cgi?type=h5ad&dataset_id=${datasetId}`;
+                            const url = `./cgi/download_source_file.cgi?type=h5ad&share_id=${shareId}`;
                             item.href = url;
                         } catch (error) {
                             logErrorInConsole(error);
@@ -923,7 +923,7 @@ class DatasetTile {
                     item.classList.add("is-hidden");
                     break;
                 default:
-                    console.warn(`Unknown dropdown item ${item.dataset.tool} for dataset ${datasetId}.`);
+                    console.warn(`Unknown dropdown item ${item.dataset.tool} for dataset ${shareId}.`);
                     break;
             }
 

--- a/www/js/compare_datasets.js
+++ b/www/js/compare_datasets.js
@@ -122,6 +122,54 @@ const datasetTree = new DatasetTree({
     })
 });
 
+/**
+ * Activates a dataset in the dataset tree based on a URL parameter.
+ *
+ * This function checks if the specified URL parameter exists, optionally fetches additional
+ * dataset information using a provided function, and then activates the corresponding dataset
+ * node in the dataset tree. If the dataset cannot be found or accessed, a toast notification
+ * is displayed and an error is thrown.
+ *
+ * @async
+ * @param {string} paramName - The name of the URL parameter to look for.
+ * @param {function} [fetchInfoFn] - Optional async function to fetch dataset info using the parameter value.
+ *        Should return a Promise that resolves to an array of objects containing a `dataset_id` property.
+ * @throws {Error} If the dataset cannot be accessed or found in the dataset tree.
+ */
+const activateDatasetFromParam = async (paramName, fetchInfoFn) => {
+    if (!urlParams.has(paramName)) {
+        return;
+    }
+    const paramValue = urlParams.get(paramName);
+    let linkedDatasetId;
+    try {
+        if (fetchInfoFn) {
+            const data = await fetchInfoFn(paramValue);
+            linkedDatasetId = data.datasets[0].id;
+            if (!linkedDatasetId) {
+                throw new Error(`Accessible dataset for ${paramName} ${paramValue} was not found`);
+            }
+        } else {
+            linkedDatasetId = paramValue;
+        }
+    } catch (error) {
+        createToast(error.message);
+        throw new Error(error);
+    }
+
+    try {
+        // find DatasetTree node and trigger "activate"
+        const foundNode = datasetTree.findFirst(e => e.data.dataset_id === linkedDatasetId);
+        foundNode.setActive(true, {focusTree:true});
+        datasetTree.tree.setActiveNode(foundNode);
+        datasetTree.selectCallback({node: foundNode});  // manually trigger the "activate" event.
+        datasetId = linkedDatasetId;
+    } catch (error) {
+        createToast(`Dataset id ${linkedDatasetId} was not found as a public/private/shared dataset`);
+        throw new Error(error);
+    }
+}
+
 const adjustGeneTableLabels = () => {
     const geneFoldchanges = document.getElementById("tbl-gene-foldchanges");
 	geneFoldchanges.replaceChildren();
@@ -1369,19 +1417,17 @@ const handlePageSpecificLoginUIUpdates = async (event) => {
 		]);
         // If brought here by the "gene search results" page, curate on the dataset ID that referred us
         const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has("dataset_id")) {
-            const linkedDatasetId = urlParams.get("dataset_id");
-            try {
-                // find DatasetTree node and trigger "activate"
-                const foundNode = datasetTree.findFirst(e => e.data.dataset_id === linkedDatasetId);
-                foundNode.setActive(true);
-                datasetTree.tree.setActiveNode(foundNode);
-                datasetTree.selectCallback({node: foundNode});  // manually trigger the "activate" event.
-                datasetId = linkedDatasetId;
-            } catch (error) {
-                createToast(`Dataset id ${linkedDatasetId} was not found as a public/private/shared dataset`);
-                throw new Error(error);
-            }
+
+
+        // Usage inside handlePageSpecificLoginUIUpdates
+        if (urlParams.has("share_id")) {
+            return await activateDatasetFromParam("share_id", async (shareId) =>
+                await apiCallsMixin.fetchDatasetListInfo({permalink_share_id: shareId})
+            );
+        } else if (urlParams.has("dataset_id")) {
+    		// Legacy support for dataset_id
+
+            await activateDatasetFromParam("dataset_id");
         }
 	} catch (error) {
 		logErrorInConsole(error);

--- a/www/js/dataset_explorer.js
+++ b/www/js/dataset_explorer.js
@@ -156,10 +156,10 @@ class ResultItem {
         setElementProperties(listItemView, ".js-edit-dataset-save", { value: datasetId });
         setElementProperties(listItemView, ".js-edit-dataset-cancel", { value: datasetId });
 
-        setElementProperties(listItemView, ".js-dataset-curator", { href: `./dataset_curator.html?dataset_id=${datasetId}`});
-        setElementProperties(listItemView, ".js-multigene-viewer", { href: `./multigene_curator.html?dataset_id=${datasetId}`});
-        setElementProperties(listItemView, ".js-compare-tool", { href: `./compare_datasets.html?dataset_id=${datasetId}`});
-        setElementProperties(listItemView, ".js-sc-workbench", { href: `./sc_workbench.html?dataset_id=${datasetId}`});
+        setElementProperties(listItemView, ".js-dataset-curator", { href: `./dataset_curator.html?share_id=${this.shareId}`});
+        setElementProperties(listItemView, ".js-multigene-viewer", { href: `./multigene_curator.html?share_id=${this.shareId}`});
+        setElementProperties(listItemView, ".js-compare-tool", { href: `./compare_datasets.html?share_id=${this.shareId}`});
+        setElementProperties(listItemView, ".js-sc-workbench", { href: `./sc_workbench.html?share_id=${this.shareId}`});
 
 
         // dataset type section
@@ -395,7 +395,7 @@ class ResultItem {
                 try {
                     // download the h5ad
                     const datasetId = this.datasetId;
-                    const url = `./cgi/download_source_file.cgi?type=h5ad&dataset_id=${datasetId}`;
+                    const url = `./cgi/download_source_file.cgi?type=h5ad&share_id=${this.shareId}`;
                     const a = document.createElement('a');
                     a.href = url;
                     a.click();

--- a/www/js/sc_workbench.js
+++ b/www/js/sc_workbench.js
@@ -122,6 +122,54 @@ const datasetTree = new DatasetTree({
 });
 
 /**
+ * Activates a dataset in the dataset tree based on a URL parameter.
+ *
+ * This function checks if the specified URL parameter exists, optionally fetches additional
+ * dataset information using a provided function, and then activates the corresponding dataset
+ * node in the dataset tree. If the dataset cannot be found or accessed, a toast notification
+ * is displayed and an error is thrown.
+ *
+ * @async
+ * @param {string} paramName - The name of the URL parameter to look for.
+ * @param {function} [fetchInfoFn] - Optional async function to fetch dataset info using the parameter value.
+ *        Should return a Promise that resolves to an array of objects containing a `dataset_id` property.
+ * @throws {Error} If the dataset cannot be accessed or found in the dataset tree.
+ */
+const activateDatasetFromParam = async (paramName, fetchInfoFn) => {
+    if (!urlParams.has(paramName)) {
+        return;
+    }
+    const paramValue = urlParams.get(paramName);
+    let linkedDatasetId;
+    try {
+        if (fetchInfoFn) {
+            const data = await fetchInfoFn(paramValue);
+            linkedDatasetId = data.datasets[0].id;
+            if (!linkedDatasetId) {
+                throw new Error(`Accessible dataset for ${paramName} ${paramValue} was not found`);
+            }
+        } else {
+            linkedDatasetId = paramValue;
+        }
+    } catch (error) {
+        createToast(error.message);
+        throw new Error(error);
+    }
+
+    try {
+        // find DatasetTree node and trigger "activate"
+        const foundNode = datasetTree.findFirst(e => e.data.dataset_id === linkedDatasetId);
+        foundNode.setActive(true, {focusTree:true});
+        datasetTree.tree.setActiveNode(foundNode);
+        datasetTree.selectCallback({node: foundNode});  // manually trigger the "activate" event.
+        datasetId = linkedDatasetId;
+    } catch (error) {
+        createToast(`Dataset id ${linkedDatasetId} was not found as a public/private/shared dataset`);
+        throw new Error(error);
+    }
+}
+
+/**
  * Counts and highlights duplicate values in the clustering group labels step.
  * @returns {number} The number of duplicate values found.
  */
@@ -545,19 +593,16 @@ const handlePageSpecificLoginUIUpdates = async (event) => {
 		await loadDatasetTree()
         // If brought here by the "gene search results" page, curate on the dataset ID that referred us
         const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has("dataset_id")) {
-            const linkedDatasetId = urlParams.get("dataset_id");
-            try {
-                // find DatasetTree node and trigger "activate"
-                const foundNode = datasetTree.findFirst(e => e.data.dataset_id === linkedDatasetId);
-                foundNode.setActive(true, {focusTree:true});
-                datasetTree.tree.setActiveNode(foundNode);
-                datasetTree.selectCallback({node: foundNode});  // manually trigger the "activate" event.
-                datasetId = linkedDatasetId;
-            } catch (error) {
-                createToast(`Dataset id ${linkedDatasetId} was not found as a public/private/shared dataset`);
-                throw new Error(error);
-            }
+
+        // Usage inside handlePageSpecificLoginUIUpdates
+        if (urlParams.has("share_id")) {
+            return await activateDatasetFromParam("share_id", async (shareId) =>
+                await apiCallsMixin.fetchDatasetListInfo({permalink_share_id: shareId})
+            );
+        } else if (urlParams.has("dataset_id")) {
+    		// Legacy support for dataset_id
+
+            await activateDatasetFromParam("dataset_id");
         }
 
         // ? This could be used to pre-select an analysis


### PR DESCRIPTION
Made this change, and left legacy support in for dataset IDs in URLs. I also changed this in the download_source_file.cgi script as the dataset_id was passed in as a param and was also used in the name of the downloaded file.

Eventually I would like to swap this in other CGI scripts (and the API routes, but for now this is a start.