### PR TITLE
Disable analysis tool if dataset doesn't allow for it

### DIFF
--- a/lib/geardb.py
+++ b/lib/geardb.py
@@ -330,6 +330,9 @@ def get_dtype_by_share_id(share_id=None):
     Given a dataset share ID string this returns the datatype string for that dataset.
     """
 
+    if not share_id:
+        return None
+
     conn = Connection()
     cursor = conn.get_cursor()
 
@@ -341,6 +344,7 @@ def get_dtype_by_share_id(share_id=None):
 
     cursor.execute(qry, (share_id,))
 
+    dtype = None
     row = cursor.fetchone()
     if row:
         (

--- a/www/css/bulma/css/bulma-rtl.css
+++ b/www/css/bulma/css/bulma-rtl.css
@@ -10800,25 +10800,6 @@ a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
 .is-hidden {
   display: none !important;
 }
-.is-analysis-tool-disabled {
-  pointer-events: none !important;
-  opacity: 0.5 !important;
-}
-.is-analysis-tool-loading button:before {
-  animation: spinAround 1s infinite linear;
-  border: 2px solid #dbdbdb;
-  border-radius: 290486px;
-  border-right-color: transparent;
-  border-top-color: transparent;
-  content: "";
-  display: inline-block;
-  right: 0.5em;
-  vertical-align: top;
-  height: 1.5em;
-  position: relative;
-  width: 1.5em;
-  margin: auto;
-}
 
 .is-sr-only {
   border: none !important;

--- a/www/css/bulma/css/bulma.css
+++ b/www/css/bulma/css/bulma.css
@@ -10800,25 +10800,6 @@ a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
 .is-hidden {
   display: none !important;
 }
-.is-analysis-tool-disabled {
-  pointer-events: none !important;
-  opacity: 0.5 !important;
-}
-.is-analysis-tool-loading button:before {
-  animation: spinAround 1s infinite linear;
-  border: 2px solid #dbdbdb;
-  border-radius: 290486px;
-  border-right-color: transparent;
-  border-top-color: transparent;
-  content: "";
-  display: inline-block;
-  right: 0.5em;
-  vertical-align: top;
-  height: 1.5em;
-  position: relative;
-  width: 1.5em;
-  margin: auto;
-}
 
 .is-sr-only {
   border: none !important;

--- a/www/css/dataset_explorer.css
+++ b/www/css/dataset_explorer.css
@@ -96,3 +96,20 @@ article[role="tooltip"] {
 .js-modal-tooltip {
     z-index: 1000; /* make sure it's on top of the modal */
 }
+
+/* Analysis tool button states */
+.js-analysis-dropdown.is-loading button::before {
+    animation: spinAround 1s infinite linear;
+    border: 2px solid #dbdbdb;
+    border-radius: 290486px;
+    border-right-color: transparent;
+    border-top-color: transparent;
+    content: "";
+    display: inline-block;
+    right: 0.5em;
+    vertical-align: top;
+    height: 1.5em;
+    position: relative;
+    width: 1.5em;
+    margin: auto;
+}

--- a/www/css/gear-theme-purple.css
+++ b/www/css/gear-theme-purple.css
@@ -5484,23 +5484,6 @@ a.has-text-gear-bg-secondary:hover, a.has-text-gear-bg-secondary:focus {
     display: inline-flex !important; } }
 .is-hidden {
   display: none !important; }
-.is-analysis-tool-disabled {
-  pointer-events: none !important;
-  opacity: 0.5 !important; }
-.is-analysis-tool-loading button:before {
-  animation: spinAround 1s infinite linear;
-  border: 2px solid #dbdbdb;
-  border-radius: 290486px;
-  border-right-color: transparent;
-  border-top-color: transparent;
-  content: "";
-  display: inline-block;
-  right: 0.5em;
-  vertical-align: top;
-  height: 1.5em;
-  position: relative;
-  width: 1.5em;
-  margin: auto; }
 
 .is-sr-only {
   border: none !important;

--- a/www/js/dataset_explorer.js
+++ b/www/js/dataset_explorer.js
@@ -218,11 +218,11 @@ class ResultItem {
 
         { // analysis links section
             const analysisDropdown = listItemView.querySelector(`.js-analysis-dropdown`);
-            analysisDropdown.classList.add("is-analysis-tool-disabled", "is-analysis-tool-loading");
+            analysisDropdown.classList.add("is-disabled", "is-loading");
 
             const tools = [ "dataset-curator", "multigene-viewer", "compare-tool", "sc-workbench" ];
             for (const tool of tools) {
-                listItemView.querySelector(`.js-${tool}`).classList.add("is-analysis-tool-disabled");
+                listItemView.querySelector(`.js-${tool}`).classList.add("is-disabled");
             }
 
             const updateAvailableTools = (availableTools) => {
@@ -236,16 +236,16 @@ class ResultItem {
                     if (availableTools[tool]) {
                         const toolElement = domElement.querySelector(`.js-${tool}`);
                         if (toolElement) {
-                            toolElement.classList.remove("is-analysis-tool-disabled");
+                            toolElement.classList.remove("is-disabled");
                             any = true;
                         }
                     }
                 }
 
                 const domAnalysisDropdown = domElement.querySelector(`.js-analysis-dropdown`);
-                domAnalysisDropdown.classList.remove("is-analysis-tool-loading");
+                domAnalysisDropdown.classList.remove("is-loading");
                 if (any) {
-                    domAnalysisDropdown.classList.remove("is-analysis-tool-disabled");
+                    domAnalysisDropdown.classList.remove("is-disabled");
                 } else {
                     domAnalysisDropdown.setAttribute("data-tooltip-content", "No analysis tools available");
                     applyTooltip(domAnalysisDropdown, createActionTooltips(domAnalysisDropdown));


### PR DESCRIPTION
A client side lookup and a server side lookup were made to update analysis tools based on if the dataset actually allows for it. Client side lookup is prioritized for speed, but if `dtype` is not stored on the client, it uses the server to lookup the type and proper tools.