### PR TITLE
tSNE legend adjustment

### DIFF
--- a/www/api/resources/tsne_data.py
+++ b/www/api/resources/tsne_data.py
@@ -49,7 +49,7 @@ PLOT_TYPE_TO_BASIS = {
 COLOR_HEX_PTRN = r"^#(?:[0-9a-fA-F]{3}){1,2}$"
 
 NUM_LEGENDS_PER_COL = (
-    12  # Max number of legend items per column allowed in vertical legend
+    20  # Max number of legend items per column allowed in vertical legend
 )
 
 parser = reqparse.RequestParser(bundle_errors=True)
@@ -1084,6 +1084,7 @@ def generate_tsne_figure(
                 frameon=False,
                 handles=handles,
                 labels=labels,
+                fontsize="small",
             )
             if horizontal_legend:
                 last_ax.get_legend().remove()  # Remove legend added by scanpy
@@ -1094,6 +1095,7 @@ def generate_tsne_figure(
                     ncol=num_horizontal_cols,
                     handles=handles,
                     labels=labels,
+                    fontsize="small",
                 )
     else:
         rename_axes_labels(ax, x_axis, y_axis)


### PR DESCRIPTION
This pull request makes minor improvements to the t-SNE figure legend in `www/api/resources/tsne_data.py`. The changes increase the maximum number of legend items per column and set a smaller font size for legend text to improve readability and layout.

Legend layout and appearance improvements:

* Increased the maximum number of legend items per column in vertical legends from 12 to 20 to allow more items per column.
* Set the legend font size to "small" for both vertical and horizontal legends to enhance readability and prevent overcrowding. [[1]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR1087) [[2]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR1098)