### PR TITLE
whoops

### DIFF
--- a/www/upload_dataset.html
+++ b/www/upload_dataset.html
@@ -172,7 +172,7 @@
                   </ul>
                 </div> <!-- end #step-c -->
                 <hr />
-                <div id="step-enter-metadata-c" class="step-c is-hidden">
+                <div id="step-enter-metadata-c" class="step-c">
                   <h1>Step - Enter metadata (via form OR upload)</h1>
                   <p>
                     The 'metadata' is the data describing your dataset, including things like title, authorship, sequencing
@@ -559,7 +559,7 @@
                   </div>
 
                 </div>
-                <div id="step-upload-dataset-c" class="step-c">
+                <div id="step-upload-dataset-c" class="step-c is-hidden">
                   <h1>Step - Upload dataset</h1>
                   <p>
                     Choose the format of your dataset and upload it here. You can also provide a URL to a supported dataset.


### PR DESCRIPTION
This pull request updates the visibility of steps in the dataset upload workflow by changing which steps are hidden or shown by default in the `www/upload_dataset.html` file. This adjustment improves the user flow by making the metadata entry step visible initially and hiding the dataset upload step until it's needed.

Changes to step visibility in the upload workflow:

* Made the metadata entry step (`step-enter-metadata-c`) visible by default, allowing users to enter metadata immediately upon reaching this part of the process.
* Hid the dataset upload step (`step-upload-dataset-c`) by default, so users are guided to complete metadata entry before uploading their dataset.