### PR TITLE
Improve spatial panel callback speed

### DIFF
--- a/services/spatial/panel_app.py
+++ b/services/spatial/panel_app.py
@@ -14,7 +14,6 @@ from common import (
     SpatialFigure,
     clip_expression_values,
 )
-from panel.reactive import debounce
 from werkzeug.utils import secure_filename
 
 gear_root = Path(__file__).resolve().parents[2]
@@ -519,7 +518,6 @@ class SpatialPanel(pn.viewable.Viewer):
             height=layout_height,
         )
 
-        @debounce(200)
         def refresh_figures_callback(value) -> None:
             # don't recreate the object, just tell it what to display
             self.use_clusters = value

--- a/services/spatial/panel_app_expanded.py
+++ b/services/spatial/panel_app_expanded.py
@@ -15,7 +15,6 @@ from common import (
     clip_expression_values,
     sort_clusters,
 )
-from panel.reactive import debounce
 from plotly.subplots import make_subplots
 from werkzeug.utils import secure_filename
 
@@ -753,7 +752,6 @@ class SpatialPanel(pn.viewable.Viewer):
         )
 
         # SAdkins - Have not quite figured out when to use "watch" but I think it mostly applies when a callback does not return a value
-        @debounce(200)
         def refresh_dataframe_callback(value):
 
             if self.df_orig is None:


### PR DESCRIPTION
This pull request improves how the spatial panel app updates its figures when toggling the "use clusters" option. Instead of recreating the entire figure object, the code now updates only the necessary parts, making the process more efficient.

Figure update optimization:

* Added a `set_use_clusters` method to the figure object (`setup_zoom_fig_params`), allowing it to update only relevant traces and colorbars when the clusters flag changes, instead of recreating the entire figure.
* Modified the `refresh_figures_callback` in the `SpatialPanel` class to use the new `set_use_clusters` method for efficient updates, and only fall back to recreating figures if needed.