### PR TITLE
Add primary analysis as module

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,6 +75,7 @@
     - Use Ruff for linting and formatting if available.
     - Type hints are encouraged but not required.
     - Follow PEP 8 style guide.
+    - Various types of comprehensions (i.e. list, generator) are acceptable, but try to avoid nested comprehensions for readability.
 
 ### ES Module code order
 1. Imports (must be at top syntax-wise)

--- a/lib/gear/primary_analysis.py
+++ b/lib/gear/primary_analysis.py
@@ -1,70 +1,17 @@
-#!/opt/bin/python3
-
-"""
-This script is a CGI handler for adding or updating primary analysis metadata to a dataset in the gEAR platform.
-It performs the following main tasks:
-- Authenticates the user via session ID.
-- Locates the dataset using a share UID.
-- Loads the primary analysis object and its associated settings JSON.
-- Detects the presence of tSNE, UMAP, and clustering results in the dataset's AnnData object.
-- Updates the AnnData object and analysis JSON to ensure tSNE, UMAP, and clustering results are present and properly recorded.
-- Writes changes to the AnnData file and analysis JSON if modifications are made.
-- Returns a JSON response indicating success or failure.
-
-Key Functions:
-- main(): Orchestrates the process of updating the primary analysis for a dataset.
-- add_clustering_analysis(adata): Adds clustering information to the AnnData object if detected.
-- add_tsne_analysis(adata): Adds tSNE coordinates to the AnnData object if detected.
-- add_umap_analysis(adata): Adds UMAP coordinates to the AnnData object if detected.
-- detect_clustering(adata): Checks if clustering columns are present in AnnData.obs.
-- detect_tsne(adata): Checks if tSNE coordinate columns are present in AnnData.obs.
-- detect_umap(adata): Checks if UMAP coordinate columns are present in AnnData.obs.
-- has_clustering(adata): Checks if clustering results are already present in AnnData.obs.
-- has_tsne(adata): Checks if tSNE results are already present in AnnData.obsm.
-- has_umap(adata): Checks if UMAP results are already present in AnnData.obsm.
-
-Constants:
-- DATASET_BASE_DIR: Base directory for datasets.
-- VALID_CLUSTER_COLUMN_NAMES: List of valid column names for clustering.
-- VALID_TSNE_PAIRS: List of valid tSNE coordinate column pairs.
-- VALID_UMAP_PAIRS: List of valid UMAP coordinate column pairs.
-
-The script is intended to be run as a CGI script during the upload process and outputs a JSON response.
-"""
-
-
-import cgi
 import json
-import os
-import shutil
-import sys
 import typing
 from pathlib import Path
 
-import numpy as np
 import scanpy as sc
-
-original_stdout = sys.stdout
-sys.stdout = open(os.devnull, 'w')
-
-gear_root_path = Path(__file__).resolve().parents[2]
-
-lib_path = gear_root_path.joinpath('lib')
-sys.path.insert(0, str(lib_path))
-
-import geardb
-from gear.analysis import H5adAdapter, ZarrAdapter
-
-sc.settings.verbosity = 0
-sc.settings.autosave = True
-sc.settings.figdir = '/tmp' # for the composition plots
+from analysis import H5adAdapter, ZarrAdapter
 
 if typing.TYPE_CHECKING:
     # This allows type-checkers to resolve types without importing the actual modules at runtime.
     # To avoid having runtime errors, enclose the typing in quotes (AKA forward-reference)
     from anndata import AnnData
 
-DATASET_BASE_DIR = '{}/www/datasets'.format(gear_root_path)
+gear_root_path = Path(__file__).resolve().parents[2]
+
 VALID_CLUSTER_COLUMN_NAMES = ['cluster', 'cell_type', 'cluster_label', 'subclass_label', 'joint_cluster_round4_annot']
 VALID_TSNE_PAIRS = [['tSNE_1', 'tSNE_2'], ['tSNE1', 'tSNE2'], ['tsne1_combined', 'tsne2_combined'],
                     # These are all carlo's custom ones.  Need to resolve this a different way later
@@ -72,57 +19,14 @@ VALID_TSNE_PAIRS = [['tSNE_1', 'tSNE_2'], ['tSNE1', 'tSNE2'], ['tsne1_combined',
 VALID_UMAP_PAIRS = [['uMAP_1', 'uMAP_2'], ['uMAP1', 'uMAP2'],
                     ['UMAP_1', 'UMAP_2'], ['UMAP1', 'UMAP2']]
 
+sc.settings.verbosity = 0
+sc.settings.autosave = True
+sc.settings.figdir = '/tmp' # for the composition plots
 
-user_upload_file_base = gear_root_path / 'www' / 'uploads' / 'files'
-
-def main() -> dict:
-    form = cgi.FieldStorage()
-    session_id = form.getvalue('session_id')
-    share_uid = form.getvalue('share_uid')
-    dataset_format = form.getvalue('dataset_format', 'single-cell-rnaseq')
-
-    result = {"success": 0, "message": "", 'perform_primary_analysis': True}
-
-    user = geardb.get_user_from_session_id(session_id)
-    if user is None:
-        result['message'] = 'User ID not found. Please log in to continue.'
-        print(result['message'], file=sys.stderr)
-        return result
-
-    if not share_uid:
-        result['message'] = 'No share ID found for dataset. Please try upload again.'
-        print(result['message'], file=sys.stderr)
-        return result
-
-    print("Processing share ID: {0}".format(share_uid))
-
-    # Load the metadata, to get spatial information
-    dataset_upload_dir = user_upload_file_base / session_id / share_uid
-    metadata_file = dataset_upload_dir / "metadata.json"
-    if not metadata_file.is_file():
-        result['message'] = 'Metadata file not found.'
-        print(result['message'], file=sys.stderr)
-        return result
-
-    with open(metadata_file, 'r') as f:
-        metadata = json.load(f)
-        dataset_id = metadata.get('dataset_uid', '')
-
-    # If the dataset type is not single-cell-rnaseq or spatial, exit gracefully
-    if metadata.get("dataset_type") not in ['single-cell-rnaseq', 'spatial']:
-        result['success'] = 1
-        result['perform_primary_analysis'] = False
-        result['message'] = 'This dataset format cannot be run in the single-cell workbench. Exiting gracefully.'
-        print(result['message'], file=sys.stderr)
-        return result
-
-    # Update that primary analysis can be performed on this dataset
-    metadata["perform_primary_analysis"] = True
-    with open(metadata_file, 'w') as f:
-        json.dump(metadata, f, indent=4)
+def add_primary_analysis_to_dataset(dataset_id, share_id, staging_dir):
 
     # Load the analysis JSON or create from template
-    analysis_json_path = dataset_upload_dir / "analysis_pipeline.json"
+    analysis_json_path = staging_dir / "analysis_pipeline.json"
     if analysis_json_path.is_file():
         with open(analysis_json_path) as json_in:
             analysis_json = json.load(json_in)
@@ -140,16 +44,16 @@ def main() -> dict:
     # Figure out how to retrieve the AnnData object based on the file type
     kwargs = {}
     if dataset_format == "spatial":
-        upload_file = dataset_upload_dir / f"{share_uid}.zarr"
+        upload_file = staging_dir / f"{share_id}.zarr"
         if not upload_file.is_dir():
-            result['message'] = f"Spatial dataset file not found for share ID: {share_uid}"
+            result['message'] = f"Spatial dataset file not found for share ID: {share_id}"
             print(result['message'], file=sys.stderr)
             return result
         adapter = ZarrAdapter(upload_file)
     else:
-        upload_file = dataset_upload_dir / f"{share_uid}.h5ad"
+        upload_file = staging_dir / f"{share_id}.h5ad"
         if not upload_file.is_file():
-            result['message'] = f"Dataset file not found for share ID: {share_uid}"
+            result['message'] = f"Dataset file not found for share ID: {share_id}"
             print(result['message'], file=sys.stderr)
             return result
         adapter = H5adAdapter(upload_file)
@@ -158,7 +62,7 @@ def main() -> dict:
     adata = adapter.get_adata(**kwargs)
 
     # Create some initial composition plots
-    create_composition_plots(adata, dataset_upload_dir, dataset_format == "spatial")
+    create_composition_plots(adata, staging_dir, dataset_format == "spatial")
 
     h5ad_changes_made = False
     json_changes_made = False
@@ -343,9 +247,3 @@ def has_umap(adata: "AnnData") -> bool:
         pass
 
     return False
-
-if __name__ == '__main__':
-    result = main()
-    sys.stdout = original_stdout
-    print('Content-Type: application/json\n\n')
-    print(json.dumps(result))

--- a/lib/gear/primary_analysis.py
+++ b/lib/gear/primary_analysis.py
@@ -1,9 +1,12 @@
 import json
+import shutil
+import sys
 import typing
 from pathlib import Path
 
 import scanpy as sc
-from analysis import H5adAdapter, ZarrAdapter
+
+from .analysis import H5adAdapter, ZarrAdapter
 
 if typing.TYPE_CHECKING:
     # This allows type-checkers to resolve types without importing the actual modules at runtime.
@@ -23,7 +26,11 @@ sc.settings.verbosity = 0
 sc.settings.autosave = True
 sc.settings.figdir = '/tmp' # for the composition plots
 
-def add_primary_analysis_to_dataset(dataset_id, share_id, staging_dir):
+class PrimaryAnalysisProcessingError(Exception):
+    """Custom exception for errors during primary analysis processing."""
+    pass
+
+def add_primary_analysis_to_dataset(dataset_id, share_id, staging_dir, dataset_format):
 
     # Load the analysis JSON or create from template
     analysis_json_path = staging_dir / "analysis_pipeline.json"
@@ -46,16 +53,12 @@ def add_primary_analysis_to_dataset(dataset_id, share_id, staging_dir):
     if dataset_format == "spatial":
         upload_file = staging_dir / f"{share_id}.zarr"
         if not upload_file.is_dir():
-            result['message'] = f"Spatial dataset file not found for share ID: {share_id}"
-            print(result['message'], file=sys.stderr)
-            return result
+            raise PrimaryAnalysisProcessingError(f"Spatial dataset file not found for share ID: {share_id}")
         adapter = ZarrAdapter(upload_file)
     else:
         upload_file = staging_dir / f"{share_id}.h5ad"
         if not upload_file.is_file():
-            result['message'] = f"Dataset file not found for share ID: {share_id}"
-            print(result['message'], file=sys.stderr)
-            return result
+            raise PrimaryAnalysisProcessingError(f"Dataset file not found for share ID: {share_id}")
         adapter = H5adAdapter(upload_file)
         kwargs["backed"] = True
 
@@ -66,9 +69,6 @@ def add_primary_analysis_to_dataset(dataset_id, share_id, staging_dir):
 
     h5ad_changes_made = False
     json_changes_made = False
-    # Does the metadata file exist?  If not, we need to create it
-    if not metadata_file.is_file():
-        json_changes_made = True
 
     tsne_detected = detect_tsne(adata)
     if tsne_detected:
@@ -116,9 +116,7 @@ def add_primary_analysis_to_dataset(dataset_id, share_id, staging_dir):
         print("\tWriting new JSON")
         with open(analysis_json_path, 'w') as outfile:
             json.dump(analysis_json, outfile, indent=3)
-
-    result['success'] = 1
-    return result
+    return True
 
 def add_clustering_analysis(adata: "AnnData") -> None:
     cols = adata.obs.columns.tolist()

--- a/www/api/resources/orthologs.py
+++ b/www/api/resources/orthologs.py
@@ -91,15 +91,11 @@ def normalize_mapped_genes(mapped_gene_symbols: list, gene_set: set, normalize_g
         list: Normalized gene symbols that exist in the dataset.
     """
     normalized_genes = []
-
     for mapped_gene_symbol in mapped_gene_symbols:
-        if not check_gene_in_dataset(gene_set, mapped_gene_symbol):
-            continue
-
-        normalized_gene = normalize_gene(mapped_gene_symbol)
-        if normalized_gene is not None:
-            normalized_genes.append(normalized_gene)
-
+        if check_gene_in_dataset(gene_set, mapped_gene_symbol):
+            normalized_gene = normalize_gene(mapped_gene_symbol)
+            if normalized_gene is not None:
+                normalized_genes.append(normalized_gene)
     return normalized_genes
 
 def check_gene_in_dataset(gene_map: set, gene_symbol: str) -> bool:

--- a/www/cgi/process_uploaded_expression_dataset.cgi
+++ b/www/cgi/process_uploaded_expression_dataset.cgi
@@ -38,7 +38,7 @@ sys.stdout = open(os.devnull, 'w')
 lib_path = Path(__file__).resolve().parents[2] / 'lib'
 sys.path.append(str(lib_path))
 import geardb
-from gear.primary_analysis import add_primary_analysis_to_dataset
+from gear.primary_analysis import add_primary_analysis_to_dataset, PrimaryAnalysisProcessingError
 from gear.spatialhandler import SPATIALTYPE2CLASS
 from gear.utils import update_adata_with_ensembl_ids
 
@@ -110,7 +110,6 @@ def main():
         dataset_uid = metadata.get('dataset_uid', '')
         dataset_type = metadata.get('dataset_type', '')
 
-
     # Update metadata for downstream uses
     metadata["dataset_format"] = dataset_format
     metadata["perform_primary_analysis"] = True if dataset_type in ['single-cell-rnaseq', 'spatial'] else False
@@ -151,26 +150,33 @@ def main():
 
     # new child command
     if dataset_format == 'mex_3tab':
-        process_mex_3tab(dataset_upload_dir)
+        process_mex_3tab(dataset_upload_dir, metadata["perform_primary_analysis"])
     elif dataset_format == 'excel':
-        process_excel(dataset_upload_dir)
+        process_excel(dataset_upload_dir, metadata["perform_primary_analysis"])
     elif dataset_format == "h5ad":
-        process_h5ad(dataset_upload_dir)
+        process_h5ad(dataset_upload_dir, metadata["perform_primary_analysis"])
     elif dataset_format == "spatial":
-        process_spatial(dataset_upload_dir, spatial_format)
+        process_spatial(dataset_upload_dir, spatial_format, metadata["perform_primary_analysis"])
     else:
         result["success"] = 0
         result["message"] = f"Unsupported dataset format: {dataset_format}"
         return result
 
     if metadata["perform_primary_analysis"]:
-        add_primary_analysis_to_dataset(dataset_uid, share_uid, dataset_upload_dir)
+        try:
+            result["success"] = add_primary_analysis_to_dataset(dataset_uid, share_uid, dataset_upload_dir, dataset_format)
+        except PrimaryAnalysisProcessingError as e:
+            write_status(dataset_upload_dir, 'error', f"Error during primary analysis: {str(e)}")
+            return result
+
+    status["progress"] = 100
+    write_status(dataset_upload_dir, 'complete', "Dataset processed successfully.")
 
     result["success"] = 1
     result["message"] = "Dataset processed successfully."
     return result
 
-def process_h5ad(upload_dir: Path) -> None:
+def process_h5ad(upload_dir: Path, perform_primary_analysis: bool) -> None:
     """
     Processes an uploaded .h5ad (AnnData) file in the specified upload directory by performing the following steps:
     1. Reads the .h5ad file as an AnnData object.
@@ -188,11 +194,18 @@ def process_h5ad(upload_dir: Path) -> None:
     # If the file is an h5ad, it should be formatted as an AnnData object already.
     # But we still want to do some sanitization of the obs dataframe.
 
+    # TODO: Read in chunks to save memory
+
     write_status(upload_dir, 'processing', 'Initializing dataset processing.')
 
     filepath = upload_dir / f"{share_uid}.h5ad"
     adata = anndata.read_h5ad(filepath)
     obs = adata.obs
+
+    total_steps = 4 if perform_primary_analysis else 3
+    step_counter = 1
+    status["progress"] = int((step_counter / total_steps) * 100)
+    write_status(upload_dir, 'processing', 'Sanitizing AnnData object')
 
     categorize_observation_columns(obs)
     adata.obs = sanitize_obs_for_h5ad(obs)
@@ -214,6 +227,10 @@ def process_h5ad(upload_dir: Path) -> None:
 
         adata = update_adata_with_ensembl_ids(adata, organism_id, "UNMAPPED_")
 
+    step_counter += 1
+    status["progress"] = int((step_counter / total_steps) * 100)
+    write_status(upload_dir, 'processing', 'Writing sanitized data to new H5AD.')
+
     h5ad_path = upload_dir / f"{share_uid}.new.h5ad"
     adata.write(h5ad_path)
 
@@ -221,9 +238,11 @@ def process_h5ad(upload_dir: Path) -> None:
     filepath.unlink()  # remove original
     h5ad_path.rename(filepath)  # rename new to original name
 
-    write_status(upload_dir, 'complete', 'Dataset processed successfully.')
+    step_counter += 1
+    status["progress"] = int((step_counter / total_steps) * 100)
+    write_status(upload_dir, 'processing', f"Finished processing dataset. {'Performing primary analysis...' if perform_primary_analysis else ''}")
 
-def process_3tab(upload_dir: Path) -> None:
+def process_3tab(upload_dir: Path, perform_primary_analysis: bool) -> None:
     import subprocess
 
     chunk_size = 500
@@ -269,6 +288,9 @@ def process_3tab(upload_dir: Path) -> None:
     # This can be an order of magnitude faster than the using python alone
     total_rows = int(subprocess.check_output(f"/usr/bin/wc -l {expression_matrix_path}", shell=True).split()[0])
 
+    if perform_primary_analysis:
+        total_rows += 1  # account for the additional primary analysis step that will be performed after this
+
     expression_matrix = []
     rows_read = 0
 
@@ -281,9 +303,8 @@ def process_3tab(upload_dir: Path) -> None:
             expression_matrix.append(sparse.csr_matrix(chunk.values))
 
             status['progress'] = percentage
-            status['message'] = f"Processed {rows_read}/{total_rows} expression matrix chunks ..."
-            with open(upload_dir / "status.json", 'w') as f:
-                f.write(json.dumps(status))
+            message = f"Processed {rows_read}/{total_rows} expression matrix chunks ..."
+            write_status(upload_dir, 'processing', message)
 
         adata.X = sparse.vstack(expression_matrix) # type: ignore
     except Exception:
@@ -314,10 +335,8 @@ def process_3tab(upload_dir: Path) -> None:
                 rows_read += chunk_size
                 percentage = int((rows_read / total_rows) * 100)
 
-                status['progress'] = percentage
-                status['message'] = f"Processed {rows_read}/{total_rows} expression matrix chunks ..."
-                with open(upload_dir / "status.json", 'w') as f:
-                    f.write(json.dumps(status))
+                message = f"Processed {rows_read}/{total_rows} expression matrix chunks ..."
+                write_status(upload_dir, 'processing', message)
 
             except Exception:
                 #print(f"\nError in chunk {chunk_index}: {inner_e}")
@@ -334,9 +353,7 @@ def process_3tab(upload_dir: Path) -> None:
             #print("Collected chunk shapes:")
             #for i, shape in enumerate(chunk_shapes):
             #    print(f"  Chunk {i+1}: {shape}")
-
             raise
-
 
     adata = adata.transpose()
     adata.obs = sanitize_obs_for_h5ad(adata.obs)
@@ -344,9 +361,10 @@ def process_3tab(upload_dir: Path) -> None:
     h5ad_path = upload_dir / f"{share_uid}.h5ad"
     adata.write(h5ad_path)
 
-    write_status(upload_dir, 'complete', 'Dataset processed successfully.')
+    # Progress is accounted for in chunk processing
+    write_status(upload_dir, 'processing', f"Finished processing dataset. {'Performing primary analysis...' if perform_primary_analysis else ''}")
 
-def process_excel(upload_dir: Path) -> None:
+def process_excel(upload_dir: Path, perform_primary_analysis: bool) -> None:
     filepath = upload_dir / f"{share_uid}.xlsx"
 
     write_status(upload_dir, 'processing', 'Initializing dataset processing.')
@@ -426,12 +444,15 @@ def process_excel(upload_dir: Path) -> None:
     h5ad_path = upload_dir / f"{share_uid}.h5ad"
     adata.write(h5ad_path)
 
-    write_status(upload_dir, 'complete', 'Dataset processed successfully.')
+    total_steps = 2 if perform_primary_analysis else 1
+    status["progress"] = int((1 / total_steps) * 100)
+    write_status(upload_dir, 'processing', f"Finished processing dataset. {'Performing primary analysis...' if perform_primary_analysis else ''}")
 
-def process_mex(upload_dir: Path) -> None:
+
+def process_mex(upload_dir: Path, perform_primary_analysis: bool) -> None:
     pass
 
-def process_mex_3tab(upload_dir: Path) -> None:
+def process_mex_3tab(upload_dir: Path, perform_primary_analysis: bool) -> None:
     # Extract the file
     import tarfile
     compression_format = None
@@ -510,11 +531,11 @@ def process_mex_3tab(upload_dir: Path) -> None:
 
     # Call the appropriate function
     if dataset_type == 'threetab':
-        process_3tab(upload_dir)
+        process_3tab(upload_dir, perform_primary_analysis)
     elif dataset_type == 'mex':
-        process_mex(upload_dir)
+        process_mex(upload_dir, perform_primary_analysis)
 
-def process_spatial(upload_dir: Path, spatial_format: str) -> None:
+def process_spatial(upload_dir: Path, spatial_format: str, perform_primary_analysis: bool) -> None:
     """
     Processes a spatial transcriptomics dataset uploaded to a specified directory.
 
@@ -531,6 +552,9 @@ def process_spatial(upload_dir: Path, spatial_format: str) -> None:
     Raises:
         Writes error status if the metadata file is missing or if reading/converting the spatial file fails.
     """
+
+    write_status(upload_dir, 'processing', 'Initializing dataset processing.')
+
     spatial_obj = SPATIALTYPE2CLASS[spatial_format]()   # instantiate the appropriate handler class
     metadata_file = upload_dir / 'metadata.json'
     if not metadata_file.is_file():
@@ -560,9 +584,16 @@ def process_spatial(upload_dir: Path, spatial_format: str) -> None:
         import shutil
         shutil.rmtree(output_path)
 
+    total_steps = 3 if perform_primary_analysis else 2
+    step_counter = 1
+    status["progress"] = int((step_counter / total_steps) * 100)
     write_status(upload_dir, 'processing', 'Writing Zarr store')
+
     spatial_obj.write_to_zarr(filepath=output_path)
-    write_status(upload_dir, 'complete', 'Dataset processed successfully.')
+
+    step_counter += 1
+    status["progress"] = int((step_counter / total_steps) * 100)
+    write_status(upload_dir, 'processing', f"Finished processing spatial dataset. {'Performing primary analysis...' if perform_primary_analysis else ''}")
 
 def sanitize_obs_for_h5ad(obs_df: pd.DataFrame) -> pd.DataFrame:
     for col in obs_df.columns:

--- a/www/cgi/process_uploaded_expression_dataset.cgi
+++ b/www/cgi/process_uploaded_expression_dataset.cgi
@@ -38,6 +38,7 @@ sys.stdout = open(os.devnull, 'w')
 lib_path = Path(__file__).resolve().parents[2] / 'lib'
 sys.path.append(str(lib_path))
 import geardb
+from gear.primary_analysis import add_primary_analysis_to_dataset
 from gear.spatialhandler import SPATIALTYPE2CLASS
 from gear.utils import update_adata_with_ensembl_ids
 
@@ -106,9 +107,14 @@ def main():
         return
     with open(metadata_file, 'r') as f:
         metadata = json.load(f)
+        dataset_uid = metadata.get('dataset_uid', '')
+        dataset_type = metadata.get('dataset_type', '')
+
 
     # Update metadata for downstream uses
     metadata["dataset_format"] = dataset_format
+    metadata["perform_primary_analysis"] = True if dataset_type in ['single-cell-rnaseq', 'spatial'] else False
+
     with open(metadata_file, 'w') as f:
         json.dump(metadata, f, indent=4)
 
@@ -156,6 +162,9 @@ def main():
         result["success"] = 0
         result["message"] = f"Unsupported dataset format: {dataset_format}"
         return result
+
+    if metadata["perform_primary_analysis"]:
+        add_primary_analysis_to_dataset(dataset_uid, share_uid, dataset_upload_dir)
 
     result["success"] = 1
     result["message"] = "Dataset processed successfully."

--- a/www/js/upload_dataset.js
+++ b/www/js/upload_dataset.js
@@ -86,18 +86,11 @@ const checkDatasetProcessingStatus = async () => {
     document.getElementById('step-process-dataset-status-message').textContent = data.message;
     document.getElementById('dataset-processing-progress').value = data.progress;
 
-    // TODO: Handle the different statuses here
+    // Only enable next button when both dataset processing AND primary analysis are complete
     if (processingStatus === 'complete') {
-        document.getElementById('step-process-dataset-status-message').textContent = "Now adding primary analysis to dataset...";
-        await addPrimaryAnalysisToDataset();
-
-        // If still complete after the primary analysis step, enable the next step button
-        if (processingStatus === "complete") {
-            document.getElementById('dataset-processing-submit').disabled = false;
-        } else {
-            document.getElementById('step-process-dataset-status').textContent = processingStatus.charAt(0).toUpperCase() + processingStatus.slice(1);
-            document.getElementById('step-process-dataset-status-message').textContent = "Error adding primary analysis to dataset";
-        }
+        document.getElementById('dataset-processing-submit').disabled = false;
+    } else if (processingStatus === 'error') {
+        document.getElementById('step-process-dataset-status-message').textContent = "Error during processing";
     }
 }
 


### PR DESCRIPTION
This pull request refactors and improves the dataset upload and primary analysis workflow, focusing on modularizing the primary analysis logic, improving error handling, and enhancing progress reporting throughout the processing of various dataset formats. The changes also update coding guidelines and fix a minor logic bug.

**Key changes include:**

### Refactoring and Modularization

* The primary analysis logic previously embedded in the CGI script (`www/cgi/add_primary_analysis_to_dataset_upload.cgi`) has been moved to a new, importable module (`lib/gear/primary_analysis.py`). This enables better code reuse and separation of concerns. The main function is replaced with `add_primary_analysis_to_dataset`, and a custom exception `PrimaryAnalysisProcessingError` is introduced for error handling. [[1]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L1-R36) [[2]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L143-L167) [[3]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L215-R119) [[4]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L346-L351)
* The main dataset upload handler (`www/cgi/process_uploaded_expression_dataset.cgi`) now imports and calls this new function, and uses the custom exception for robust error reporting. [[1]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR41) [[2]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL148-R179)

### Progress Reporting and User Feedback

* Progress reporting is improved throughout the dataset processing pipeline for all supported formats (H5AD, 3-tab, Excel, spatial). The progress indicator and status messages are updated at each significant step, including during chunked processing of large files and when performing primary analysis. [[1]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR197-R209) [[2]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR230-R245) [[3]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR291-R293) [[4]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL275-R307) [[5]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL308-R339) [[6]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL420-R455) [[7]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL504-R538) [[8]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR587-R596)

### API and Logic Improvements

* All processing functions (`process_h5ad`, `process_3tab`, `process_excel`, `process_mex_3tab`, `process_spatial`) now accept a `perform_primary_analysis` argument, allowing the workflow to conditionally perform primary analysis based on dataset type and user input. [[1]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL148-R179) [[2]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL504-R538)
* The metadata file is updated to include a `perform_primary_analysis` flag, and this flag is used to control downstream processing.

### Coding Guidelines and Minor Fixes

* The Python coding guidelines are updated to discourage nested comprehensions for readability. (.github/copilot-instructions.md)
* A logic bug in gene normalization is fixed: now, only gene symbols present in the dataset are normalized and returned.

---

**References:**  
[[1]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L1-R36) [[2]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L143-L167) [[3]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L215-R119) [[4]](diffhunk://#diff-ca9e8bdb868a2c76a44cfd1d18b3115e933eb3f6f11c113abc7f16417ab686c6L346-L351) [[5]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR41) [[6]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR110-R116) [[7]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL148-R179) [[8]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR197-R209) [[9]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR230-R245) [[10]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR291-R293) [[11]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL275-R307) [[12]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL308-R339) [[13]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL420-R455) [[14]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aL504-R538) [[15]](diffhunk://#diff-8e89b951d321237ef29bcdd8d6575f6335926d2e2459f9655cf3a9cac2935f7aR587-R596) [[16]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R78) [[17]](diffhunk://#diff-7b55f120995cbbf08dcace4a5d02cc73010e9c6cbc27cac58247e13673b560bbL94-L102)