### PR TITLE
Hotfix duplicate expression search listeners

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -85,48 +85,6 @@ document.getElementById('genes-manually-entered').addEventListener('keydown', (e
     }
 });
 
-document.getElementById('submit-expression-search').addEventListener('click', (event) => {
-    const status = validateExpressionSearchForm();
-
-    if (!status) {
-        return;
-    }
-
-    // build the URL for a GET request
-    const url = new URL('/expression.html', window.location.origin);
-
-    // add the manually-entered genes
-    // TODO: need to combine selected_genes here to accommodate the case where a gene cart
-    //  chosen but the individual genes removed.
-    const manuallyEnteredGenes =  Array.from(new Set([...selected_genes, ...manually_entered_genes]));
-    if (manuallyEnteredGenes.length > 0) {
-        url.searchParams.append('gene_symbol', manuallyEnteredGenes.join(','));
-    }
-
-    // are we doing exact matches?
-    if (document.getElementById('gene-search-exact-match').checked) {
-        url.searchParams.append('gene_symbol_exact_match', '1');
-    }
-
-    // get the value of the single-multi radio box
-    const singleMulti = document.querySelector('input[name="single-multi"]:checked').value;
-    url.searchParams.append('is_multigene', singleMulti === 'single' ? '0' : '1');
-
-    // add the gene lists
-    //  TODO: This will only be for labeling purposes, since individual genes could have been
-    //    deselected within
-    if (selected_gene_lists.size > 0) {
-        const geneCartShareIds = Array.from(selected_gene_lists);
-        url.searchParams.append('gene_lists', geneCartShareIds.join(','));
-    }
-
-    // add the dataset collections
-    url.searchParams.append('layout_id', selected_dc_share_id);
-
-    // now go there
-    window.location.href = url.toString();
-});
-
 // For this page we want the gene collection dropdown to be right-aligned
 const geneCollectionDropdown = document.getElementById('dropdown-gene-lists');
 geneCollectionDropdown.classList.remove('is-left');


### PR DESCRIPTION
This pull request removes the event listener and associated logic for the expression search submit button from `www/js/index.js`. The code previously handled form validation, URL construction, and navigation for the expression search feature.

**Removal of expression search submit logic:**

* Removed the entire click event listener for the `submit-expression-search` button, including form validation, URL construction with selected genes and gene lists, and navigation logic.