### PR TITLE
Hotfix add sr only to header

### DIFF
--- a/www/include/header_bar.html
+++ b/www/include/header_bar.html
@@ -1,4 +1,4 @@
-          <a href="#content-c" class="skip-to-main-content">Skip to main content</a>
+          <a href="#content-c" class="skip-to-main-content is-sr-only">Skip to main content</a>
           <section id="header-bar">
             <nav class="navbar" role="navigation" aria-label="main navigation">
             <div class="navbar-brand">


### PR DESCRIPTION
This pull request includes a minor accessibility improvement to the header bar. The "Skip to main content" link is now visually hidden except for screen readers, making it less intrusive for sighted users while remaining accessible.

- Accessibility:
  * Added the `is-sr-only` class to the "Skip to main content" link in `header_bar.html` to visually hide it while keeping it accessible to screen readers.