### PR TITLE
Hotfix epigenomics url bugfix

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.13.5
 aiohttp_retry==2.9.1
 anndata==0.12.11
+bio==1.8.3
 biocode==0.10.0
 cairosvg==2.7.1
 colorcet==3.1.0

--- a/docs/developer/setup/new_server.md
+++ b/docs/developer/setup/new_server.md
@@ -9,26 +9,20 @@ NOTE: Extra apt install commands are present in the R setup and in the python se
 ```bash
     sudo apt update
     sudo apt upgrade
-    sudo apt install build-essential \  # installs gcc, g++, make
+    sudo apt install build-essential \
         curl \
+        git \
         rsync \
-        vim \   # Shaun Adkins was here
+        vim \
         unzip \
         wget \
         ca-certificates \
-        fonts-roboto \    # Matplotlib font
+        fonts-roboto \
         fontconfig
     sudo fc-cache -f -v    # cache the fonts
 ```
 
 Reboot if there are kernel updates (or just to be safe if you don't know.)
-
-```bash
-    cd && mkdir git
-    sudo apt install git
-    cd git
-    git clone https://github.com/IGS/gEAR.git
-```
 
 ### MYSQL
 

--- a/docs/developer/setup/python.md
+++ b/docs/developer/setup/python.md
@@ -107,6 +107,7 @@ I cannot add comments to the bash code without breaking the command.  So consult
     aiohttp==3.13.5 \
     aiohttp_retry==2.9.1 \
     anndata==0.12.11 \
+    bio==1.8.3 \
     biocode==0.10.0 \
     cairosvg==2.7.1 \
     colorcet==3.1.0 \

--- a/docs/developer/setup/r_rpy2.md
+++ b/docs/developer/setup/r_rpy2.md
@@ -24,7 +24,7 @@ sudo DEBIAN_FRONTEND="noninteractive" apt -qq install -y --no-install-recommends
   libwebp-dev \
   libgit2-dev \
   libuv1-dev \
-  tzdata \
+  tzdata
 sudo apt -qq clean autoclean
 sudo apt -qq autoremove -y
 sudo rm -rf /var/lib/apt/lists/*

--- a/www/api/resources/gosling_spec.py
+++ b/www/api/resources/gosling_spec.py
@@ -97,6 +97,8 @@ def _validate_hub_url(hub_url: str) -> None:
             raise ValueError("Domain URL not configured. Cannot process track hub.")
 
         # Build allowed domains list from configuration
+        parsed_domain_url = urlparse(domain_url)
+        domain_url = parsed_domain_url.hostname
         allowed_domains = [domain_url]
 
 


### PR DESCRIPTION
Main changes are:

a) Correcting some "docs" documentaton
b) Fixing a bug in hub url validation for gosling tracks, which would reject all gosling hubs

This pull request includes several updates to development setup documentation, package dependencies, and a minor code improvement. The main changes are the addition of the `bio` Python package, streamlining of setup instructions, and a small bug fix in domain URL parsing.

**Dependency updates:**

* Added the `bio==1.8.3` package to both `docker/requirements.txt` and the Python setup instructions, ensuring this dependency is installed in all environments. [[1]](diffhunk://#diff-43595f15069f96010c3ba429e9aa268aecf572c2a9963dde285cad2c0ad3839bR4) [[2]](diffhunk://#diff-c2020a4af64a5a70d7a3830a3d12f2c7162bbf47cc33840b6855117ef5601ce3R110)

**Setup documentation improvements:**

* Updated `new_server.md` to remove redundant `git` installation steps, add `git` to the main install command, and clean up comments in the apt install block for clarity and maintainability.
* Removed a trailing backslash in the apt install command in `r_rpy2.md` for better shell compatibility.

**Bug fix:**

* In `gosling_spec.py`, fixed domain parsing by extracting the hostname from the configured domain URL before adding it to the allowed domains list, improving URL validation logic.