### PR TITLE
Hotfix gene list ldesc html

### DIFF
--- a/www/js/gene_list_manager.js
+++ b/www/js/gene_list_manager.js
@@ -225,7 +225,9 @@ class ResultItem {
     addDescriptionInfo(parentElt) {
         // Add ldesc if it exists
         const ldescText = parentElt.querySelector(".js-display-ldesc-text");
-        ldescText.textContent = this.longDesc || "No description entered";
+        const span = document.createElement("span");
+        span.innerHTML = this.longDesc || "No description entered";
+        ldescText.replaceChildren(span);		
     }
 
     addListItemEventListeners(parentElt) {
@@ -381,7 +383,9 @@ class ResultItem {
                 }
 
                 selector.querySelector(`.js-display-title p`).textContent = newTitle;
-                selector.querySelector(`.js-display-ldesc-text`).textContent = newLdesc || "No description entered";
+                const ldescSpan = document.createElement("span");
+                ldescSpan.innerHTML = newLdesc || "No description entered";
+                selector.querySelector(`.js-display-ldesc-text`).replaceChildren(ldescSpan);
 
                 selector.querySelector(`.js-display-organism span:last-of-type`).textContent = newOrgText;
             }


### PR DESCRIPTION
This pull request updates how long descriptions are rendered in the gene list manager to allow for HTML formatting. Instead of setting the text content directly, long descriptions are now injected as HTML within a `span` element. This enables richer formatting in descriptions while maintaining a fallback for missing values.

**Rendering improvements for long descriptions:**

* In the `ResultItem` class within `www/js/gene_list_manager.js`, the `addDescriptionInfo` and list item update logic now use a `span` element with `innerHTML` to render `longDesc` values, allowing HTML content in descriptions. [[1]](diffhunk://#diff-040c47b3db59bc855c7445530adc8a5cb70d081af3e3de3eb5bc802cb1438783L228-R230) [[2]](diffhunk://#diff-040c47b3db59bc855c7445530adc8a5cb70d081af3e3de3eb5bc802cb1438783L384-R388)