### PR TITLE
Potential fix for code scanning alert no. 332: Client-side cross-site scripting

### DIFF
--- a/www/js/dataset_explorer.js
+++ b/www/js/dataset_explorer.js
@@ -1915,7 +1915,7 @@ const createRenameCollectionPermalinkPopover = () => {
                         </a>
                     </div>
                     <div class='control'>
-                        <input id='collection-link-name' class='input' type='text' placeholder='permalink' value=${datasetCollectionState.selectedShareId}>
+                        <input id='collection-link-name' class='input' type='text' placeholder='permalink'>
                     </div>
                 </div>
                 <div class='field is-grouped' style='width:250px'>
@@ -1932,6 +1932,11 @@ const createRenameCollectionPermalinkPopover = () => {
 
         // append element to DOM to get its dimensions
         document.body.appendChild(popoverContent);
+
+        const collectionLinkNameInput = document.getElementById('collection-link-name');
+        if (collectionLinkNameInput) {
+            collectionLinkNameInput.value = datasetCollectionState.selectedShareId || "";
+        }
 
         const arrowElement = document.getElementById('arrow');
 


### PR DESCRIPTION
Potential fix for [https://github.com/IGS/gEAR/security/code-scanning/332](https://github.com/IGS/gEAR/security/code-scanning/332)

Best fix: avoid injecting untrusted data via `innerHTML`. Build the popover skeleton with static HTML only, then set dynamic values through safe DOM APIs (`textContent` / `.value` / `setAttribute`). This preserves behavior and eliminates HTML parsing of attacker-controlled content.

In `www/js/dataset_explorer.js`, inside `createRenameCollectionPermalinkPopover`, update the block that sets `popoverContent.innerHTML` so the `<input>` does not include `${datasetCollectionState.selectedShareId}` in markup. After appending to DOM, set the input’s `.value` programmatically from `datasetCollectionState.selectedShareId` (default empty string). This is the minimal, functionally equivalent remediation and requires no new imports/dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
