### PR TITLE
Resolve 1277

### DIFF
--- a/www/api/resources/tsne_data.py
+++ b/www/api/resources/tsne_data.py
@@ -82,6 +82,7 @@ parser.add_argument("center_around_median", type=bool, default=False)
 parser.add_argument('vmax', type=float, default=None)
 parser.add_argument('vmin', type=float, default=None)
 parser.add_argument("make_zero_gray", type=bool, default=True)  # Keep with old plot styles
+parser.add_argument("enforce_equal_aspect", type=bool, default=False)
 parser.add_argument("obs_filters", type=dict, default={})  # dict of lists
 parser.add_argument(
     "projection_id", type=str, default=None
@@ -731,6 +732,7 @@ def generate_tsne_figure(
     horizontal_legend: bool = False,
     expression_min_clip: float | None = None,
     make_zero_gray: bool = True,
+    enforce_equal_aspect: bool = False,
     skip_gene_plot=None,
     plot_by_group=None,
     two_way_palette=None,
@@ -793,6 +795,8 @@ def generate_tsne_figure(
         Minimum expression value to clip.
     make_zero_gray : bool
         Whether to make the zero-value expression color gray or the minimum colorscale color.
+    enforce_equal_aspect : bool
+        Whether to enforce equal aspect ratio on the plot axes.
     skip_gene_plot : bool or None, optional
         If True, skips plotting the gene expression plot (single-gene mode).
     plot_by_group : str or None, optional
@@ -1047,6 +1051,7 @@ def generate_tsne_figure(
             "font.sans-serif":['Roboto'],
             'font.family': 'sans-serif',
             'legend.frameon': False,     # No box around legends
+            'legend.fontsize': 'medium',
             'xtick.color': '#cccccc',
             'ytick.color': '#cccccc',   # Unfortunately changes colorbar ticks
         }
@@ -1055,6 +1060,7 @@ def generate_tsne_figure(
     sc.set_figure_params(**fig_params)
 
     io_fig: "Figure" = sc.pl.embedding(selected, **kwargs)  # type: ignore
+
     #io_fig.set_layout_engine("compressed")
     ax = io_fig.get_axes()
 
@@ -1064,13 +1070,22 @@ def generate_tsne_figure(
             # Fix the gray colorbar text (if it exists for expression plots)
             # This finds the colorbar axis and resets label color to dark
             f.spines[['top', 'right']].set_visible(False)
+
+            # Check if the axes actually contains scatter data.
+            # This prevents you from accidentally squishing colorbars or legend axes.
+            # TODO: Test this in place of the if f.get_label == "<colorbar>"
+            #if not f.collections:
+            #    continue
+
             if f.get_label() == "<colorbar>":
                 f.tick_params(labelcolor='#333333')
                 continue
             rename_axes_labels(f, x_axis, y_axis)
 
-            # Ensure axes are square (which is typically the case with the coordinate systems we use)
-            #f.set_aspect("equal")
+            # Ensure axes are square
+            if enforce_equal_aspect:
+                f.set_aspect("equal", adjustable="box")
+            f.margins(0.02) # Reduce from the default margins
 
         last_ax = ax[-1]  # color axes
         if colorize_by and color_category:
@@ -1096,7 +1111,6 @@ def generate_tsne_figure(
                 frameon=False,
                 handles=handles,
                 labels=labels,
-                fontsize="small",
             )
             if horizontal_legend:
                 last_ax.get_legend()
@@ -1109,16 +1123,19 @@ def generate_tsne_figure(
                     ncol=num_horizontal_cols,
                     handles=handles,
                     labels=labels,
-                    fontsize="small",
                 )
     else:
         ax.spines[['top', 'right']].set_visible(False)
         if ax.get_label() == '<colorbar>':
             # should never happen
             ax.tick_params(labelcolor='#333333')
-        rename_axes_labels(ax, x_axis, y_axis)
-        # Ensure axes are square (which is typically the case with the coordinate systems we use)
-        #ax.set_aspect("equal")
+        else:
+            rename_axes_labels(ax, x_axis, y_axis)
+
+            # Ensure axes are square
+            if enforce_equal_aspect:
+                ax.set_aspect("equal", adjustable="box")
+            ax.margins(0.02)
 
     # Clean up
     if selected.isbacked:
@@ -1191,7 +1208,8 @@ class MGTSNEData(Resource):
             args.get("max_columns", None),
             args.get("horizontal_legend", False),
             args.get("expression_min_clip", None),
-            args.get("make_zero_gray", True)
+            args.get("make_zero_gray", True),
+            args.get("enforce_equal_aspect", False)
         )
 
 
@@ -1234,6 +1252,7 @@ class TSNEData(Resource):
             args.get("horizontal_legend", False),
             args.get("expression_min_clip", None),
             args.get("make_zero_gray", True),
+            args.get("enforce_equal_aspect", False),
             args.get("skip_gene_plot", False),
             args.get("plot_by_group", None),
             args.get("two_way_palette", False),

--- a/www/include/plot_config/post_plot/tsne_static.html
+++ b/www/include/plot_config/post_plot/tsne_static.html
@@ -36,6 +36,12 @@
 <p class="help">Split samples into category groups, then create plots per group.</p>
 
 <p class="is-flex is-justify-content-space-between pr-3 mb-1">
+    <span class="has-text-weight-medium">Enforce equal aspect ratio</span>
+    <input class="js-tsne-enforce-equal-aspect" id="enforce-equal-aspect-post" type="checkbox">
+</p>
+<p class="help">Make the axes square, ensuring equal scaling on both axes for all subplots.</p>
+
+<p class="is-flex is-justify-content-space-between pr-3 mb-1">
     <span class="has-text-weight-medium">Number of subplot columns</span>
     <input class="js-tsne-max-columns" id="max-columns-post" type="number" min="0" max="9" value="3" disabled aria-label="Number of subplot columns"/>
 </p>

--- a/www/js/dataset_curator.js
+++ b/www/js/dataset_curator.js
@@ -308,6 +308,7 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
         , "js-tsne-flip-y": "flip_y"
         , "js-tsne-colorize-legend-by": "colorize_legend_by"
         , "js-tsne-plot-by-series": "plot_by_group"
+        , "js-tsne-enforce-equal-aspect": "enforce_equal_aspect"
         , "js-tsne-max-columns": "max_columns"
         , "js-tsne-skip-gene-plot": "skip_gene_plot"
         , "js-tsne-horizontal-legend": "horizontal_legend"

--- a/www/js/multigene_curator.js
+++ b/www/js/multigene_curator.js
@@ -780,6 +780,7 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
         , "js-tsne-flip-x": "flip_x"
         , "js-tsne-flip-y": "flip_y"
         , "js-tsne-colorize-legend-by": "colorize_legend_by"
+        , "js-tsne-enforce-equal-aspect": "enforce_equal_aspect"
         , "js-tsne-max-columns": "max_columns"
         , "js-tsne-horizontal-legend": "horizontal_legend"
         , "js-tsne-marker-size": "marker_size"


### PR DESCRIPTION
This pull request adds a new option to enforce equal aspect ratio on t-SNE plots, ensuring that the axes are square and scaling is consistent. The change is implemented across the backend API, plotting logic, frontend HTML controls, and JavaScript data handling. Additional minor improvements to plot appearance are also included.

**t-SNE Plot Aspect Ratio Control:**

* Added a new `enforce_equal_aspect` argument to the t-SNE plotting API (`generate_tsne_figure`) and its documentation, allowing users to request square axes for all subplots. [[1]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR85) [[2]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR735) [[3]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR798-R799)
* Updated the plotting logic to apply an equal aspect ratio to axes when `enforce_equal_aspect` is set, including margin adjustments for better layout. [[1]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR1073-R1088) [[2]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaL1112-R1138)

**Frontend and Data Handling:**

* Added a new checkbox control to the t-SNE plot configuration UI for enabling "Enforce equal aspect ratio," with a description for user guidance.
* Integrated the new option into the JavaScript handlers for both single-gene and multi-gene t-SNE plot forms, ensuring the value is passed to the backend. [[1]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddR311) [[2]](diffhunk://#diff-3a4bb6af99e5e24f7bb631e8db75595a45ece529dd2e1d65941f85fff3daa58aR783)

**Plot Appearance Improvements:**

* Set a default legend font size in plot parameters for improved readability.
* Removed explicit legend font size settings from legend creation calls to rely on the global parameter. [[1]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaL1099) [[2]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaL1112-R1138)