### PR TITLE
Fix names for autogenerated citations

### DIFF
--- a/www/js/classes/citation.js
+++ b/www/js/classes/citation.js
@@ -29,29 +29,41 @@ export class Citation {
     }
 
     static APA(authors, year, title, shareId, accessDate, license) {
-        authors = authors.map(author => {
-            const names = author.split(' ').map(s => s.trim());
-            const lastName = names.pop();
+        if (authors === null) {
+            accessDate = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
 
-            const initials = names.map(n => n[0].toUpperCase() + '.').join(' ');
-            return `${lastName}, ${initials}`;
-        });
-        if (authors.length === 1) {
-            authors = authors[0];
-        } else if (authors.length <= 20) {
-            authors = authors.slice(0, -1).join(', ') + ' & ' + authors.slice(-1);
+            if (license)
+                license = ` Licensed under ${license}.`;
+
+            return {
+                orig: `${title} (${year}). [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`,
+                format: `<i>${title}</i> (${year}). [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`
+            };
         } else {
-            authors = authors.slice(0, 19).join(', ') + ', ... & ' + authors.slice(-1);
+            authors = authors.map(author => {
+                const names = author.split(' ').map(s => s.trim());
+                const lastName = names.pop();
+
+                const initials = names.map(n => n[0].toUpperCase() + '.').join(' ');
+                return `${lastName}, ${initials}`;
+            });
+            if (authors.length === 1) {
+                authors = authors[0];
+            } else if (authors.length <= 20) {
+                authors = authors.slice(0, -1).join(', ') + ' & ' + authors.slice(-1);
+            } else {
+                authors = authors.slice(0, 19).join(', ') + ', ... & ' + authors.slice(-1);
+            }
+
+            accessDate = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+
+            if (license)
+                license = ` Licensed under ${license}.`;
+
+            return {
+                orig: `${authors} (${year}). ${title} [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`,
+                format: `${authors} (${year}). <i>${title}</i> [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`
+            };
         }
-
-        accessDate = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
-
-        if (license)
-            license = ` Licensed under ${license}.`;
-
-        return {
-            orig: `${authors} (${year}). ${title} [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`,
-            format: `${authors} (${year}). <i>${title}</i> [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`
-        };
     }
 }

--- a/www/js/classes/citation.js
+++ b/www/js/classes/citation.js
@@ -17,53 +17,48 @@ export class Citation {
             authors = authors[0];
         }
 
-        accessDate = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+        const accessTimeStamp = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
 
-        if (license)
-            license = ` Licensed under ${license}.`;
+        const licenseToUse = license ? ` Licensed under ${license}.` : "";
 
         return {
-            orig: `${authors} (${year}). ${title}. Available from ${Citation.getDOI(shareId)} (Accessed ${accessDate}).${license || ""}`,
-            format: `${authors} (${year}). <i>${title}</i>. Available from ${Citation.getDOI(shareId)} (Accessed ${accessDate}).${license || ""}`
+            orig: `${authors} (${year}). ${title}. Available from ${Citation.getDOI(shareId)} (Accessed ${accessTimeStamp}).${licenseToUse}`,
+            format: `${authors} (${year}). <i>${title}</i>. Available from ${Citation.getDOI(shareId)} (Accessed ${accessTimeStamp}).${licenseToUse}`
         }
     }
 
     static APA(authors, year, title, shareId, accessDate, license) {
+        const accessTimestamp = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+
+        const licenseToUse = license ? ` Licensed under ${license}.` : "";
+
+        // If there are no authors, we should start with the title
         if (authors === null) {
-            accessDate = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
-
-            if (license)
-                license = ` Licensed under ${license}.`;
-
             return {
-                orig: `${title} (${year}). [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`,
-                format: `<i>${title}</i> (${year}). [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`
-            };
-        } else {
-            authors = authors.map(author => {
-                const names = author.split(' ').map(s => s.trim());
-                const lastName = names.pop();
-
-                const initials = names.map(n => n[0].toUpperCase() + '.').join(' ');
-                return `${lastName}, ${initials}`;
-            });
-            if (authors.length === 1) {
-                authors = authors[0];
-            } else if (authors.length <= 20) {
-                authors = authors.slice(0, -1).join(', ') + ' & ' + authors.slice(-1);
-            } else {
-                authors = authors.slice(0, 19).join(', ') + ', ... & ' + authors.slice(-1);
-            }
-
-            accessDate = accessDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
-
-            if (license)
-                license = ` Licensed under ${license}.`;
-
-            return {
-                orig: `${authors} (${year}). ${title} [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`,
-                format: `${authors} (${year}). <i>${title}</i> [Data set]. gEAR Portal. Retrieved ${accessDate}, from ${Citation.getDOI(shareId)}.${license || ""}`
+                orig: `${title} (${year}). [Data set]. gEAR Portal. Retrieved ${accessTimestamp}, from ${Citation.getDOI(shareId)}.${licenseToUse}`,
+                format: `<i>${title}</i> (${year}). [Data set]. gEAR Portal. Retrieved ${accessTimestamp}, from ${Citation.getDOI(shareId)}.${licenseToUse}`
             };
         }
+
+        // Convert authors to "Last, F. M." format
+        authors = authors.map(author => {
+            const names = author.split(' ').map(s => s.trim());
+            const lastName = names.pop();
+
+            const initials = names.map(n => n[0].toUpperCase() + '.').join(' ');
+            return `${lastName}, ${initials}`;
+        });
+        if (authors.length === 1) {
+            authors = authors[0];
+        } else if (authors.length <= 20) {
+            authors = `${authors.slice(0, -1).join(', ')} & ${authors.slice(-1)}`;
+        } else {
+            authors = `${authors.slice(0, 19).join(', ')}, ... & ${authors.slice(-1)}`;
+        }
+
+        return {
+            orig: `${authors} (${year}). ${title} [Data set]. gEAR Portal. Retrieved ${accessTimestamp}, from ${Citation.getDOI(shareId)}.${licenseToUse}`,
+            format: `${authors} (${year}). <i>${title}</i> [Data set]. gEAR Portal. Retrieved ${accessTimestamp}, from ${Citation.getDOI(shareId)}.${licenseToUse}`
+        };
     }
 }

--- a/www/js/classes/tilegrid.js
+++ b/www/js/classes/tilegrid.js
@@ -854,12 +854,13 @@ class DatasetTile {
                 case "cite":
                     item.addEventListener("click", async (event) => {
                         let modalHTML;
+                        console.log(dataset);
                         if (pubmedId) {
                             modalHTML = this.createModalCitation(apiCallsMixin.fetchCitationFromPubmedId(pubmedId));
                         } else {
                             const citation = {
                                 apa: Citation.APA(
-                                    [ dataset.user_name ],
+                                    (dataset.contact_name ?? null) === null ? null : [ dataset.contact_name ], // if contact name is null or undefined, pass null to APA function, otherwise pass as array
                                     new Date(dataset.date_added).getFullYear(),
                                     dataset.title,
                                     dataset.share_id,

--- a/www/js/classes/tilegrid.js
+++ b/www/js/classes/tilegrid.js
@@ -854,7 +854,6 @@ class DatasetTile {
                 case "cite":
                     item.addEventListener("click", async (event) => {
                         let modalHTML;
-                        console.log(dataset);
                         if (pubmedId) {
                             modalHTML = this.createModalCitation(apiCallsMixin.fetchCitationFromPubmedId(pubmedId));
                         } else {


### PR DESCRIPTION
Autogenerated citations use the `contact_name` property instead of `user_name` property.
If `contact_name` is `undefined` or `null`, the citation is generated without an author name as defined by the APA standards.