### PR TITLE
Resolves #1281

### DIFF
--- a/www/api/resources/tsne_data.py
+++ b/www/api/resources/tsne_data.py
@@ -97,6 +97,9 @@ single_gene_parser.add_argument(
     "plot_by_group", type=str, default=None
 )  # If true, plot by group
 single_gene_parser.add_argument(
+    "hide_group_nonmembers", type=bool, default=False
+)  # If true, hide data points not belonging to the group
+single_gene_parser.add_argument(
     "skip_gene_plot", type=bool, default=False
 )  # If true, skip the gene expression plot
 single_gene_parser.add_argument(
@@ -735,6 +738,7 @@ def generate_tsne_figure(
     enforce_equal_aspect: bool = False,
     skip_gene_plot=None,
     plot_by_group=None,
+    hide_group_nonmembers=False,
     two_way_palette=None,
 ) -> dict:
     """
@@ -801,6 +805,8 @@ def generate_tsne_figure(
         If True, skips plotting the gene expression plot (single-gene mode).
     plot_by_group : str or None, optional
         Name of the group to split plots by.
+    hide_group_nonmembers: bool, optional
+        Whether to hide data points that are not members of a particular group when using plot_by_group.
     two_way_palette : str or None, optional
         Name of a two-way color palette for special sorting.
 
@@ -970,14 +976,14 @@ def generate_tsne_figure(
             # This will create a new column for each group in the plot_by_group
             for _, name in enumerate(column_order):
                 group_name = name + "_split_by_group"
+
                 selected.obs[group_name] = selected.obs.apply(
-                    lambda row: row["gene_expression"]
-                    if row[plot_by_group] == name
-                    else 0,
-                    axis=1,
+                    lambda row: row["gene_expression"] if row[plot_by_group] == name else np.nan, axis=1
                 )
+
                 columns.append(group_name)
                 titles.append(name)
+
             kwargs_ncols = max_cols
 
             # Set vmax if not provided
@@ -1002,6 +1008,7 @@ def generate_tsne_figure(
         "basis": basis,
         "color": columns,
         "color_map": expression_color,
+        "na_color": "none" if hide_group_nonmembers else "lightgray",  # "none" is shorthand for completely transparent
         "show": False,
         "use_raw": False,
         "title": titles,
@@ -1253,7 +1260,9 @@ class TSNEData(Resource):
             args.get("expression_min_clip", None),
             args.get("make_zero_gray", True),
             args.get("enforce_equal_aspect", False),
+            # These options are not in the multigene plot args.
             args.get("skip_gene_plot", False),
             args.get("plot_by_group", None),
+            args.get("hide_group_nonmembers", False),
             args.get("two_way_palette", False),
         )

--- a/www/include/plot_config/post_plot/tsne_static.html
+++ b/www/include/plot_config/post_plot/tsne_static.html
@@ -20,6 +20,12 @@
     <input class="js-tsne-flip-y" id="flip-y-post" type="checkbox">
 </label>
 
+<p class="is-flex is-justify-content-space-between pr-3 mb-1">
+    <span class="has-text-weight-medium">Enforce equal aspect ratio</span>
+    <input class="js-tsne-enforce-equal-aspect" id="enforce-equal-aspect-post" type="checkbox">
+</p>
+<p class="help">Make the axes square, ensuring equal scaling on both axes for all subplots.</p>
+
 <p class="is-flex is-justify-content-space-between pr-3">
     <span class="has-text-weight-medium">Colorize samples by</span>
     <span class="select is-small">
@@ -36,10 +42,11 @@
 <p class="help">Split samples into category groups, then create plots per group.</p>
 
 <p class="is-flex is-justify-content-space-between pr-3 mb-1">
-    <span class="has-text-weight-medium">Enforce equal aspect ratio</span>
-    <input class="js-tsne-enforce-equal-aspect" id="enforce-equal-aspect-post" type="checkbox">
+    <span class="has-text-weight-medium">Hide group non-members</span>
+    <input class="js-tsne-hide-group-nonmembers" id="hide-group-nonmembers-post" type="checkbox" disabled>
 </p>
-<p class="help">Make the axes square, ensuring equal scaling on both axes for all subplots.</p>
+<p class="help">For each category group, hide data points that are not members of that group.</p>
+
 
 <p class="is-flex is-justify-content-space-between pr-3 mb-1">
     <span class="has-text-weight-medium">Number of subplot columns</span>
@@ -78,12 +85,12 @@
     <input class="js-tsne-reverse-palette" id="reverse-palette-post" type="checkbox">
 </label>
 <label class="content is-flex is-justify-content-space-between pr-3 mb-1 checkbox">
-    <span class="has-text-weight-medium">Check to make non-expression values gray</span>
+    <span class="has-text-weight-medium">Make non-expression values gray</span>
     <input class="js-tsne-make-zero-gray" id="make-zero-gray-post" type="checkbox" checked>
 </label>
 <p class="help">Expression values that have a value of zero will be gray instead of the minimum colorscale color.</p>
 <label class="content is-flex is-justify-content-space-between pr-3 checkbox">
-    <span class="has-text-weight-medium">Check to bring highest and lowest values to front of plot</span>
+    <span class="has-text-weight-medium">Bring highest and lowest values to front of plot</span>
     <input class="js-tsne-two-way-palette" id="two-way-palette-post" type="checkbox">
 </label>
 <label class="content is-flex is-justify-content-space-between pr-3 mb-1 checkbox">

--- a/www/js/dataset_curator.js
+++ b/www/js/dataset_curator.js
@@ -308,6 +308,7 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
         , "js-tsne-flip-y": "flip_y"
         , "js-tsne-colorize-legend-by": "colorize_legend_by"
         , "js-tsne-plot-by-series": "plot_by_group"
+        , "js-tsne-hide-group-nonmembers": "hide_group_nonmembers"
         , "js-tsne-enforce-equal-aspect": "enforce_equal_aspect"
         , "js-tsne-max-columns": "max_columns"
         , "js-tsne-skip-gene-plot": "skip_gene_plot"
@@ -354,6 +355,7 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
 
         // Restoring some disabled/checked elements in UI
         const plotBySeries = document.getElementsByClassName("js-tsne-plot-by-series");
+        const hideGroupNonmembers = document.getElementsByClassName("js-tsne-hide-group-nonmembers");
         const maxColumns = document.getElementsByClassName('js-tsne-max-columns');
         const skipGenePlot = document.getElementsByClassName("js-tsne-skip-gene-plot");
         const horizontalLegend = document.getElementsByClassName("js-tsne-horizontal-legend");
@@ -362,7 +364,7 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
 
         if (config["colorize_legend_by"]) {
             const series = config["colorize_legend_by"];
-            for (const targetElt of [...plotBySeries, ...horizontalLegend]) {
+            for (const targetElt of [...plotBySeries, ...hideGroupNonmembers, ...horizontalLegend]) {
                 targetElt.disabled = true;
                 if (catColumns.includes(series)) {
                     targetElt.disabled = false;
@@ -404,8 +406,14 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
                 targetElt.checked = false;
                 curatorCommon.disableCheckboxLabel(targetElt, targetElt.disabled);
             }
-            for (const targetElt of [...maxColumns]) {
+            for (const targetElt of [...maxColumns, ...hideGroupNonmembers]) {
                 targetElt.disabled = false;
+            }
+        } else {
+            for (const targetElt of [...hideGroupNonmembers]) {
+                targetElt.disabled = true;
+                targetElt.checked = false;
+                curatorCommon.disableCheckboxLabel(targetElt, targetElt.disabled);
             }
         }
 
@@ -544,11 +552,13 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
             this.plotConfig["max_columns"] = null;
             this.plotConfig["skip_gene_plot"] = false;
             this.plotConfig["horizontal_legend"] = false;
+            this.plotConfig["hide_group_nonmembers"] = false;
         }
 
         // if no plot-by-group is selected, ensure max columns is not passed to the scanpy code
         if (!(document.getElementById("plot-by-group-series-post").value)) {
             this.plotConfig["max_columns"] = null;
+            this.plotConfig["hide_group_nonmembers"] = false;
         }
 
         // If override marker size is not checked, ensure it does not get passed to the scanpy code
@@ -1385,6 +1395,7 @@ const setupScanpyOptions = async (datasetId) => {
 
     const colorizeLegendBy = document.getElementsByClassName("js-tsne-colorize-legend-by");
     const plotBySeries = document.getElementsByClassName("js-tsne-plot-by-series");
+    const hideGroupNonmembers = document.getElementsByClassName("js-tsne-hide-group-nonmembers");
     const maxColumns = document.getElementsByClassName('js-tsne-max-columns');
     const skipGenePlot = document.getElementsByClassName("js-tsne-skip-gene-plot");
     const horizontalLegend = document.getElementsByClassName("js-tsne-horizontal-legend");
@@ -1403,7 +1414,7 @@ const setupScanpyOptions = async (datasetId) => {
             }
 
             // The "max columns" parameter should only be disabled if the colorized legend is continuous
-            for (const targetElt of [...maxColumns]) {
+            for (const targetElt of [...maxColumns, ...hideGroupNonmembers]) {
                 targetElt.disabled = catColumns.includes(event.target.value) ? false : true;
                 curatorCommon.disableCheckboxLabel(targetElt, targetElt.disabled);
             }
@@ -1434,7 +1445,7 @@ const setupScanpyOptions = async (datasetId) => {
                 curatorCommon.disableCheckboxLabel(targetElt, targetElt.disabled);
             }
             // Must be allowed to specify max columns if series value selected
-            for (const targetElt of [...maxColumns]) {
+            for (const targetElt of [...maxColumns, ...hideGroupNonmembers]) {
                 targetElt.disabled = event.target.value ? false : true;
                 curatorCommon.disableCheckboxLabel(targetElt, targetElt.disabled);
             }

--- a/www/js/multigene_curator.js
+++ b/www/js/multigene_curator.js
@@ -933,6 +933,7 @@ class ScanpyHandler extends curatorCommon.PlotHandler {
 
         // Remove some single-gene options from the post-plot adjustments
         const plotBySeries = document.querySelector(".js-tsne-plot-by-series");
+        const hideGroupNonmembers = document.querySelector(".js-tsne-hide-group-nonmembers");
         const skipGenePlot = document.querySelector(".js-tsne-skip-gene-plot");
         const twoWayPalette = document.querySelector(".js-tsne-two-way-palette");
         for (const targetElt of [plotBySeries, skipGenePlot, twoWayPalette]) {


### PR DESCRIPTION
This pull request enhances the t-SNE plotting functionality by introducing an option to hide non-members when splitting plots by group, and updates both backend and frontend logic to support this feature. It also improves the user interface and ensures the correct handling of plot configuration options.

**t-SNE Group Non-member Hiding Feature:**

* Added a new `hide_group_nonmembers` option to the t-SNE API and backend, allowing users to hide data points that are not members of the selected group when plotting by group. This is implemented by setting non-member points to `NaN` and making them transparent in the plot. [[1]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR99-R101) [[2]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR741) [[3]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR808-R809) [[4]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR979-R986) [[5]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR1011) [[6]](diffhunk://#diff-6e4c861ff4d4370b97a13b2f77cb5d179a5588fdb6cf961f338f1311fb30eefaR1263-R1266)

**Frontend and UI Updates:**

* Updated the t-SNE plot configuration UI (`tsne_static.html`) to include a "Hide group non-members" checkbox, with logic to enable/disable it based on other selections. Improved help text for several options for clarity. [[1]](diffhunk://#diff-d8ec579cd817316e1b3961890cba73890759f4beeb90862d874d5df824542de2R23-R28) [[2]](diffhunk://#diff-d8ec579cd817316e1b3961890cba73890759f4beeb90862d874d5df824542de2L39-R49) [[3]](diffhunk://#diff-d8ec579cd817316e1b3961890cba73890759f4beeb90862d874d5df824542de2L81-R93)
* Modified JavaScript handlers (`dataset_curator.js`) to correctly map, enable, disable, and reset the new `hide_group_nonmembers` option in response to user interactions and configuration changes. [[1]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddR311) [[2]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddR358) [[3]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddL365-R367) [[4]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddL407-R417) [[5]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddR555-R561) [[6]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddR1398) [[7]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddL1406-R1417) [[8]](diffhunk://#diff-89a317861525344dc1f3cb325bcdef7519feb3323d734bc7839d7441d6bc2dddL1437-R1448)
* Ensured that the new option is not present in the multi-gene post-plot adjustment UI, maintaining correct option visibility.