### PR TITLE
1304 spatial viewer   better image caching

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,12 +59,12 @@ RUN fc-cache -f -v
 ENV LLVM_CONFIG=/usr/bin/llvm-config-14
 
 # Copy compiled Python from builder stage
-COPY --from=gear-python-base:latest /opt/Python-${PYTHON_FULL_VERSION} /opt/Python-${PYTHON_FULL_VERSION}
+COPY --from=adkinsrs/gear-python-base:latest /opt/Python-${PYTHON_FULL_VERSION} /opt/Python-${PYTHON_FULL_VERSION}
 
 # Copy compiled R from r-builder stage
-COPY --from=gear-r-base:latest /usr/local/lib/R /usr/local/lib/R
-COPY --from=gear-r-base:latest /usr/local/bin/R /usr/local/bin/R
-COPY --from=gear-r-base:latest /usr/local/bin/Rscript /usr/local/bin/Rscript
+COPY --from=adkinsrs/gear-r-base:latest /usr/local/lib/R /usr/local/lib/R
+COPY --from=adkinsrs/gear-r-base:latest /usr/local/bin/R /usr/local/bin/R
+COPY --from=adkinsrs/gear-r-base:latest /usr/local/bin/Rscript /usr/local/bin/Rscript
 
 # Link Python and shared library
 RUN mkdir -p /opt/bin \

--- a/lib/gear/spatialhandler.py
+++ b/lib/gear/spatialhandler.py
@@ -30,6 +30,25 @@ def _remove_dir(dir_to_remove: str) -> None:
     if os.path.isdir(dir_to_remove):
         subprocess.run(["rm", "-rf", dir_to_remove], check=True)
 
+def _select_pyramid_level(img, max_dim: int = 4000):
+    """
+    Picks the smallest available pyramid level whose largest dimension is
+    still >= max_dim, avoiding loading higher resolution than needed.
+    Falls back to the smallest level available if all are below max_dim.
+
+    Useful for downsampling large images to a manageable size for processing, while still retaining sufficient detail.
+    """
+    levels = list(sd.get_pyramid_levels(img))
+    if not levels:
+        raise ValueError("No pyramid levels found for this image.")
+
+    best = levels[0]
+    for level in levels:
+        if max(level.sizes.get('y', 0), level.sizes.get('x', 0)) < max_dim:
+            break
+        best = level
+    return best
+
 class SpatialHandler(ABC):
     """
     Abstract base class for handling spatial transcriptomics data, providing a unified interface for managing and processing spatial and annotated data objects.
@@ -331,7 +350,7 @@ class SpatialHandler(ABC):
         self.adata = adata
         return self
 
-    def extract_img(self) -> np.ndarray:
+    def extract_img(self) -> tuple[dict[str, np.ndarray], tuple]:
         """
         Extracts an image from the spatial data object and returns it as a NumPy array in (y, x, c) format.
 
@@ -340,24 +359,29 @@ class SpatialHandler(ABC):
         to a NumPy array and its axes are rearranged from (c, y, x) to (y, x, c).
 
         Returns:
-            np.ndarray: The extracted image as a NumPy array in (y, x, c) format.
+            tuple: A tuple containing:
+                dict[str, np.ndarray]: The extracted image as a NumPy array in (y, x, c) format.
+                tuple: The original height and width of the image.
 
         Raises:
             Exception: If `self.img_name` is not specified.
         """
-
         if not self.img_name:
             raise Exception("No image name specified for conversion to 2D array.")
 
         img = self.sdata.images[self.img_name]
+        orig_height, orig_width = None, None
         if isinstance(img, xarray.DataTree):
-            img = sd.get_pyramid_levels(img, n=0)
+            full_res = sd.get_pyramid_levels(img, n=0)
+            orig_height, orig_width = full_res.sizes.get('y'), full_res.sizes.get('x')
+            img = _select_pyramid_level(img, max_dim=4000)
+        else:
+            orig_height, orig_width = img.sizes.get('y'), img.sizes.get('x')
 
-        # Convert xarray DataArray to numpy array
         img = img.to_numpy()
+        # change dims from (c, y, x) to (y, x, c)
+        return {"composite": np.moveaxis(img, 0, -1)}, (orig_height, orig_width)
 
-        # Currently the image is in (c, y, x) format, and needs to be converted to (y, x, c) format
-        return np.moveaxis(img, 0, -1)
 
     def merge_centroids_with_obs(self) -> "SpatialHandler":
         """
@@ -1287,6 +1311,31 @@ class XeniumHandler(SpatialHandler):
     def img_name(self) -> str | None:
         """Returns the image name associated with this handler."""
         return "morphology_focus"
+
+    def extract_img(self) -> tuple[dict[str, np.ndarray], tuple]:
+        """
+        Xenium images carry multiple independently-meaningful stain channels
+        (e.g. DAPI, PolyT) -- split them apart rather than keep them as one
+        composite, since (unlike RGB) they don't need to be combined to be
+        individually useful.
+        """
+        if not self.img_name:
+            raise Exception("No image name specified for conversion to 2D array.")
+
+        orig_height, orig_width = None, None
+        img = self.sdata.images[self.img_name]
+        if isinstance(img, xarray.DataTree):
+            full_res = sd.get_pyramid_levels(img, n=0)
+            orig_height, orig_width = full_res.sizes.get('y'), full_res.sizes.get('x')
+            # Get a downsized version of the image for processing
+            img = _select_pyramid_level(img, max_dim=4000)
+
+        channel_dim = img.dims[0]
+        # Extract names of the various staining channels.  Can also just be "0" if no channel names are present.
+        channel_names = [str(c) for c in img.coords[channel_dim].to_numpy()]
+
+        arr = img.to_numpy()  # (c, y, x)
+        return {name: arr[i] for i, name in enumerate(channel_names)}, (orig_height, orig_width)  # each already (y, x)
 
     def process_file(self, filepath: str, **kwargs) -> "SpatialHandler":
         """

--- a/services/spatial/common.py
+++ b/services/spatial/common.py
@@ -1,13 +1,14 @@
+import json
 from pathlib import Path
 
 import colorcet as cc
 import datashader as ds
+import holoviews as hv
 import numpy as np
 import pandas as pd
 import param
 from bokeh.models import CustomJS, CustomJSHover, HoverTool, Span
 from holoviews.operation.datashader import spread
-import holoviews as hv
 from werkzeug.utils import secure_filename
 
 gear_root = Path(__file__).resolve().parents[2]
@@ -531,20 +532,44 @@ def retrieve_dataframe(dataset_id, filename) -> pd.DataFrame:
 
     return pd.read_csv(df_path)
 
-def retrieve_image_array(dataset_id) -> np.ndarray | None:
+def retrieve_image_array(dataset_id, channel_name=None) -> np.ndarray | None:
     """
     Retrieve a spatial image array from the cache for a given dataset ID.
 
     Args:
         dataset_id (str): The identifier of the dataset. Will be sanitized using secure_filename.
+        channel_name (str, optional): The name of the channel to retrieve. If None, retrieves the first available channel.
 
     Returns:
         np.ndarray | None: The image array if it exists, otherwise None.
     """
-    dataset_id = secure_filename(dataset_id)  # type: ignore
-    spatial_img_path = PANEL_CSV_CACHE_DIR / dataset_id / SPATIAL_IMAGE_NAME
-    if spatial_img_path.is_file():
-        return np.load(spatial_img_path)
+    dataset_id = secure_filename(dataset_id)
+    img_dir = PANEL_CSV_CACHE_DIR / dataset_id
+    if channel_name is not None:
+        path = img_dir / f"spatial_img_{secure_filename(channel_name)}.npy"
+        return np.load(path) if path.is_file() else None
+    # If no channel name is provided, attempt to load the first available spatial image file
+    candidates = sorted(img_dir.glob("spatial_img*.npy"))
+    if not candidates:
+        raise FileNotFoundError(f"No spatial image files found in {img_dir}")
+    return np.load(candidates[0]) if candidates else None
+
+def retrieve_image_dims(dataset_id) -> tuple[int, int] | None:
+    """
+    Retrieve the dimensions of a spatial image from the cache for a given dataset ID.
+
+    Args:
+        dataset_id (str): The identifier of the dataset. Will be sanitized using secure_filename.
+
+    Returns:
+        tuple[int, int] | None: The height and width of the image if it exists, otherwise None.
+    """
+    dataset_id = secure_filename(dataset_id)
+    dims_path = PANEL_CSV_CACHE_DIR / dataset_id / "spatial_props.json"
+    if dims_path.is_file():
+        with open(dims_path) as f:
+            d = json.load(f)
+        return d["height"], d["width"]
     return None
 
 def sort_clusters(clusters) -> list:

--- a/services/spatial/common.py
+++ b/services/spatial/common.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+import sys
 
 import colorcet as cc
 import datashader as ds
@@ -288,21 +289,11 @@ def create_violin_plot(df, y_col, group_col='cluster', cmap='Category10', title=
     """Generates standard bokeh violin plots (no Datashader needed here)."""
     plot_title = title if title else f"Expression Distribution: {y_col}"
 
-    # Bokeh will try to wrap in a list, so we need to convert to a flattened list of hex colors.
-    if isinstance(cmap, dict):
-        # Determine the exact order of categories Bokeh will use
-        if hasattr(df[group_col], 'cat'):
-            categories = df[group_col].cat.categories
-        else:
-            categories = sorted(df[group_col].unique())
-
-        cmap = [cmap.get(cat, '#CCCCCC') for cat in categories]
-
     # Sort df by the group_col
     df = df.sort_values(by=group_col)
 
     plot = df.hvplot.violin(
-        y=y_col, by=group_col, c=group_col, cmap=cmap,
+        y=y_col, by=group_col, color=group_col, cmap=cmap,
         ylabel='Expression', xlabel='Annotation Cluster',
         title=plot_title,
         min_height=400, responsive=True, legend=False

--- a/services/spatial/panel_common.py
+++ b/services/spatial/panel_common.py
@@ -32,7 +32,7 @@ from PIL import Image as PILImage
 
 # CRITICAL: Initialize the Bokeh backend for interactivity
 hvplot.extension('bokeh', logo=False) # type: ignore
-pn.extension(loading_indicator=True, defer_load=True, nthreads=4)  # type: ignore)
+pn.extension(loading_indicator=True, defer_load=True, nthreads=4)  # type: ignore
 
 MAX_CARD_WIDTH = 1800
 EXPANDED_PLOT_MIN_HEIGHT = 380

--- a/services/spatial/panel_common.py
+++ b/services/spatial/panel_common.py
@@ -25,6 +25,7 @@ from common import (
     normalize_expression_name,
     retrieve_dataframe,
     retrieve_image_array,
+    retrieve_image_dims,
     sort_clusters,
 )
 from PIL import Image as PILImage
@@ -174,53 +175,31 @@ class BaseSpatialViewer(pn.viewable.Viewer):
 
         self.nosave = self.settings.nosave
 
-        # Set up the background image and its dimmed version for overlaying on the plots
-        self.bg_image = None
-        self.bg_image_dimmed = None
-        self.img_height = None
-        self.img_width = None
+        # Retrieve the image array and its dimensions. If the dimensions are not available, infer them from the image array itself.
+        self.image_array = retrieve_image_array(self.settings.dataset_id)
+        orig_dims = retrieve_image_dims(self.settings.dataset_id)
+
+        self.img_height, self.img_width = None, None
+        if orig_dims is not None:
+            self.img_height, self.img_width = orig_dims
+        elif self.image_array is not None:
+            self.img_height, self.img_width = self.image_array.shape[0], self.image_array.shape[1]
 
         if self.image_array is not None:
-            # Store the original image dimensions for later use.
-            self.img_height = self.image_array.shape[0]
-            self.img_width = self.image_array.shape[1]
-
-            # Downsample if the image is too large to avoid memory issues and improve performance
-            MAX_DIM = 4000
-            if max(self.img_height, self.img_width) > MAX_DIM:
-                scale = MAX_DIM / max(self.img_height, self.img_width)
-                new_h, new_w = int(self.img_height * scale), int(self.img_width * scale)
-                # Downsample per-channel via PIL (numpy has no built-in image resize)
-                arr = self.image_array
-                if arr.ndim == 2:
-                    arr = arr[..., np.newaxis]
-                channels = [np.array(PILImage.fromarray(arr[..., c]).resize((new_w, new_h))) for c in range(arr.shape[-1])]
-                self.image_array = np.stack(channels, axis=-1)
-
-            # Ensure array contents are UInt8 (0-255) for proper display. If not, normalize to that range and convert.
             if self.image_array.dtype != np.uint8:
-                img = self.image_array.astype(np.float32)  # was implicit float64 but more memory intensive than needed
-                # Use percentile clipping to avoid outliers dominating the normalization
+                img = self.image_array.astype(np.float32)
                 p_low, p_high = np.percentile(img, [1, 99])
                 img = np.clip(img, p_low, p_high)
-                img = 255 * (img - p_low) / (p_high - p_low + 1e-8)
-                self.image_array = img.astype(np.uint8)
+                self.image_array = (255 * (img - p_low) / (p_high - p_low + 1e-8)).astype(np.uint8)
 
             # Normalize to a consistent channel count. Xenium uploads
             # in particular can come back as single-channel (H,W,1), or with 2+
             # channels for different stains -- neither is directly RGB/RGBA-usable.
             if self.image_array.ndim == 2:
                 self.image_array = self.image_array[..., np.newaxis]
-            n_channels = self.image_array.shape[-1]
-
-            # Xenium case
-            if n_channels == 1:
+            if self.image_array.shape[-1] == 1:
+                # xenium single-channel case, broadcast to RGB
                 self.image_array = np.repeat(self.image_array, 3, axis=-1)
-            elif n_channels == 2 or n_channels > 4:
-                # Ambiguous/multi-stain -- use the first channel only, matching
-                # the old Plotly pipeline's approach, then broadcast to RGB
-                # TODO: let the user select channels, though we have lost this info in the npy file.
-                self.image_array = np.repeat(self.image_array[..., :1], 3, axis=-1)
 
             # use original image_array shape to build image bounds.
             # Image is 3-dimensional where shape is (y, x, c)

--- a/services/spatial/requirements.txt
+++ b/services/spatial/requirements.txt
@@ -1,7 +1,6 @@
 hvplot==0.12.2
 panel==1.9.3
 pandas==2.3.3
-Pillow==12.2.0
 #pyarrow==18.1.0 # v19 breaks reading spatial parquet files (used by Visium HD and Xenium)
 spatialpandas==0.5.0
 werkzeug==3.1.0

--- a/www/api/resources/spatialpanel.py
+++ b/www/api/resources/spatialpanel.py
@@ -1,4 +1,5 @@
 
+import json
 import os
 import sys
 import typing
@@ -12,6 +13,7 @@ import spatialdata as sd
 from bokeh.embed import server_document
 from flask import request
 from flask_restful import Resource
+from werkzeug.utils import secure_filename
 
 from .common import create_projection_adata
 
@@ -108,7 +110,7 @@ def prep_sdata(dataset_id: str) -> "SpatialHandler":
     spatial_obj.sdata = sdata
     return spatial_obj
 
-def generate_spatial_image_df(spatial_obj: "SpatialHandler") -> np.ndarray | None:
+def generate_spatial_image_df(spatial_obj) -> tuple[dict[str, np.ndarray], tuple[int,int]] | None:
     """
     Generate a NumPy array representation of the spatial image for a given SpatialHandler.
 
@@ -125,31 +127,18 @@ def generate_spatial_image_df(spatial_obj: "SpatialHandler") -> np.ndarray | Non
 
     Returns
     -------
-    np.ndarray | None
-        A NumPy array containing the image data if extraction succeeds, otherwise
-        None when no image is available or an error occurred during extraction.
-
-    Notes
-    -----
-    - Errors raised by spatial_obj.extract_img() are handled internally; they will
-      not be propagated to the caller. Instead, a message describing the failure
-      is written to sys.stderr.
-    - This function is intended for non-fatal retrieval of optional image data.
-
-    Examples
-    --------
-    >>> arr = generate_spatial_image_df(spatial_obj)
-    >>> if arr is not None:
-    ...     # process the NumPy array
-    ...     pass
+    tuple[dict[str, np.ndarray], tuple[int,int]] | None
+        A tuple containing:
+            - A dictionary mapping channel names to their corresponding NumPy arrays.
+            - A tuple containing the original height and width of the image.
+        If extraction fails, returns None.
     """
 
     try:
         return spatial_obj.extract_img()
     except Exception as e:
-        # This is not a fatal error. Some spatial datasets do not have images
         print(f"No image found or error converting image to dataframe: {e}", file=sys.stderr)
-    return None
+        return None
 
 def create_gene_df(adata: "AnnData", gene_symbol: str) -> pd.DataFrame:
     """
@@ -413,18 +402,26 @@ class SpatialPanel(Resource):
         try:
             spatial_obj = prep_sdata(dataset_id)
 
-            # Generate spatial image if not already cached
             spatial_img = None
-            spatial_img_path = DATASET_DIR / "spatial_img.npy"
-            if spatial_img_path.is_file():
-                # Load so that the right glasbey colors can be mapped to the clusters
-                spatial_img = np.load(spatial_img_path)
-            else:
-                spatial_img = generate_spatial_image_df(spatial_obj)
-
-                if spatial_img is not None:
-                    spatial_img_path = DATASET_DIR / "spatial_img.npy"
-                    np.save(spatial_img_path, spatial_img)
+            if spatial_obj.has_images:
+                # Generate spatial image if not already cached
+                existing = list(DATASET_DIR.glob("spatial_img*.npy"))
+                if existing:
+                    spatial_img = np.load(existing[0])  # any one, just for map_colors presence check
+                else:
+                    result = generate_spatial_image_df(spatial_obj)
+                    if result is not None:
+                        channels, (orig_h, orig_w) = result
+                        # If there's only one channel, rename it to "default" for consistency
+                        if len(channels) == 1:
+                            only_key = next(iter(channels))
+                            channels = {"default": channels[only_key]}
+                        # Save each channel as a separate .npy file in the dataset directory
+                        for channel_name, arr in channels.items():
+                            np.save(DATASET_DIR / f"spatial_img_{secure_filename(channel_name)}.npy", arr)
+                        with open(DATASET_DIR / "spatial_props.json", "w") as f:
+                            json.dump({"height": orig_h, "width": orig_w}, f)
+                        spatial_img = next(iter(channels.values()))  # just for the map_colors presence check
 
             adata = spatial_obj.sdata.tables["table"]
 


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the spatial image extraction, caching, and retrieval pipeline, with a focus on supporting multi-channel images (such as those from Xenium), improving image normalization, and enhancing API consistency. The changes also include Dockerfile updates and minor dependency cleanups.

**Spatial image extraction and caching improvements:**

* The spatial image extraction logic in `SpatialHandler` now returns a dictionary of channel names to NumPy arrays (rather than a single composite array), along with the original image dimensions. This allows for proper handling of multi-channel images where each channel has independent meaning (e.g., DAPI, PolyT in Xenium) [[1]](diffhunk://#diff-6cf1cde5619b17b49bde33d7725a94c4f57009fd3f42d13254272d44b8ad9a7cL334-R353) [[2]](diffhunk://#diff-6cf1cde5619b17b49bde33d7725a94c4f57009fd3f42d13254272d44b8ad9a7cL343-L360) [[3]](diffhunk://#diff-6cf1cde5619b17b49bde33d7725a94c4f57009fd3f42d13254272d44b8ad9a7cR1315-R1339).
* The API resource responsible for generating and caching spatial images now saves each channel as a separate `.npy` file and stores the image dimensions in a `spatial_props.json` file. If only one channel is present, it is named `"default"` for consistency.

**Image retrieval and normalization:**

* The retrieval logic for spatial images has been updated to support loading specific channels by name and to retrieve image dimensions from the new `spatial_props.json` file. If no channel is specified, the first available image is loaded.
* The panel initialization code now uses the cached image dimensions (if available) and normalizes images to `uint8` with percentile clipping for robust display. Single-channel images are broadcast to RGB, and multi-channel Xenium images are handled more flexibly.

**Supporting utilities and refactoring:**

* Added a utility function `_select_pyramid_level` to select the appropriate pyramid level for downsampling large images efficiently.
* The violin plot generation was simplified to use the correct color argument and to remove redundant color mapping logic.

**Docker and dependency updates:**

* The Dockerfile was updated to pull base images from the correct repository namespace (`adkinsrs/gear-python-base` and `adkinsrs/gear-r-base`).
* The unused `Pillow` dependency was removed from `requirements.txt`.

These changes collectively enhance the flexibility, robustness, and maintainability of the spatial image handling pipeline, especially for advanced multi-channel imaging platforms.