### PR TITLE
Spatial caching changes - part 2

### DIFF
--- a/services/spatial/download_plugin.py
+++ b/services/spatial/download_plugin.py
@@ -4,7 +4,7 @@ import panel as pn
 from panel_app_expanded import ExpandedSpatialViewer
 from tornado.web import HTTPError, RequestHandler
 
-pn.extension("bokeh", loading_indicator=True, defer_load=True, nthreads=4)
+pn.extension(loading_indicator=True, defer_load=True, nthreads=4)
 
 class DownloadHandler(RequestHandler):
     """

--- a/services/spatial/panel_common.py
+++ b/services/spatial/panel_common.py
@@ -169,8 +169,6 @@ class BaseSpatialViewer(pn.viewable.Viewer):
         self.orig_df['clusters'] = self.orig_df['clusters'].astype('category')
         self.orig_df = clip_expression_values(self.orig_df, self.settings.expression_min_clip)
 
-        self.image_array = retrieve_image_array(self.settings.dataset_id)
-
         self.current_gene = normalize_expression_name(self.settings.filename)
 
         self.nosave = self.settings.nosave
@@ -186,20 +184,6 @@ class BaseSpatialViewer(pn.viewable.Viewer):
             self.img_height, self.img_width = self.image_array.shape[0], self.image_array.shape[1]
 
         if self.image_array is not None:
-            if self.image_array.dtype != np.uint8:
-                img = self.image_array.astype(np.float32)
-                p_low, p_high = np.percentile(img, [1, 99])
-                img = np.clip(img, p_low, p_high)
-                self.image_array = (255 * (img - p_low) / (p_high - p_low + 1e-8)).astype(np.uint8)
-
-            # Normalize to a consistent channel count. Xenium uploads
-            # in particular can come back as single-channel (H,W,1), or with 2+
-            # channels for different stains -- neither is directly RGB/RGBA-usable.
-            if self.image_array.ndim == 2:
-                self.image_array = self.image_array[..., np.newaxis]
-            if self.image_array.shape[-1] == 1:
-                # xenium single-channel case, broadcast to RGB
-                self.image_array = np.repeat(self.image_array, 3, axis=-1)
 
             # use original image_array shape to build image bounds.
             # Image is 3-dimensional where shape is (y, x, c)

--- a/www/api/resources/spatialpanel.py
+++ b/www/api/resources/spatialpanel.py
@@ -140,6 +140,44 @@ def generate_spatial_image_df(spatial_obj) -> tuple[dict[str, np.ndarray], tuple
         print(f"No image found or error converting image to dataframe: {e}", file=sys.stderr)
         return None
 
+def normalize_image_array(arr: np.ndarray|None) -> np.ndarray:
+    """
+    This function takes a NumPy array (which may be of any numeric type) and normalizes
+    its values to the range [0, 255], converting it to uint8 format.
+
+    Occasionally when viewing the raw image channel values, outliers can skew the color mapping.
+    To mitigate this, the function clips the values to the 1st and 99th percentiles before normalization.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input image array of any numeric type.
+
+    Returns
+    -------
+    np.ndarray
+        Normalized image array in uint8 format, with shape (H, W, 3) for RGB images.
+        If the input is grayscale, it will be converted to RGB by repeating the
+        single channel across the three RGB channels.
+    """
+    if arr is None:
+        raise ValueError("Image array is None")
+
+    if arr.dtype != np.uint8:
+        img = arr.astype(np.float32)
+        p_low, p_high = np.percentile(img, [1, 99])
+        img = np.clip(img, p_low, p_high)
+        arr = (255 * (img - p_low) / (p_high - p_low + 1e-8)).astype(np.uint8)
+
+    if arr is None:
+        raise ValueError("Image array is None after normalization")
+
+    if arr.ndim == 2:
+        arr = arr[..., np.newaxis]
+    if arr.shape[-1] == 1:
+        arr = np.repeat(arr, 3, axis=-1)
+    return arr
+
 def create_gene_df(adata: "AnnData", gene_symbol: str) -> pd.DataFrame:
     """
     Create a pandas DataFrame for a single gene from an AnnData object, including spatial,
@@ -415,9 +453,11 @@ class SpatialPanel(Resource):
                         # If there's only one channel, rename it to "default" for consistency
                         if len(channels) == 1:
                             only_key = next(iter(channels))
-                            channels = {"default": channels[only_key]}
+                            arr = normalize_image_array(channels[only_key])
+                            channels = {"default": arr}
                         # Save each channel as a separate .npy file in the dataset directory
                         for channel_name, arr in channels.items():
+                            arr = normalize_image_array(arr)
                             np.save(DATASET_DIR / f"spatial_img_{secure_filename(channel_name)}.npy", arr)
                         with open(DATASET_DIR / "spatial_props.json", "w") as f:
                             json.dump({"height": orig_h, "width": orig_w}, f)

--- a/www/js/classes/tilegrid.js
+++ b/www/js/classes/tilegrid.js
@@ -2351,7 +2351,7 @@ class DatasetTile {
 
                 // Polling Loop with a timeout if it takes too long.
                 let attempts = 0;
-                const maxAttempts = 300; // 20 seconds maximum wait time (100ms * 300)
+                const maxAttempts = 600; // 1 minute maximum wait time (100ms * 600)
 
                 const checkRender = setInterval(() => {
                     attempts++;


### PR DESCRIPTION
This pull request introduces improvements to image normalization and handling in the spatial panel workflow, ensuring more consistent and robust processing of image arrays. The key changes include centralizing and standardizing image normalization, updating image saving logic, and adjusting frontend polling behavior.

**Image normalization and handling:**

* Introduced `normalize_image_array` in `www/api/resources/spatialpanel.py` to standardize image array normalization, including percentile clipping and RGB conversion, ensuring all images are consistently processed and stored in `uint8` format.
* Updated the image saving logic in the `post` method to apply normalization to all image channels before saving, guaranteeing that saved images are properly formatted.
* Removed redundant image normalization code from `services/spatial/panel_common.py`, as normalization is now handled centrally.
* Removed the retrieval of `image_array` in `_get_restore_range`, likely to avoid unnecessary or duplicate processing.

**Frontend polling adjustment:**

* Increased the maximum polling attempts in `www/js/classes/tilegrid.js` from 300 to 600, extending the wait time for rendering from 20 seconds to 1 minute to accommodate longer image processing times.

**Other:**

* Removed the `"bokeh"` argument from the `pn.extension` call in `services/spatial/download_plugin.py`, to fix an annoying warning message